### PR TITLE
Fix syntax highlighting for camelCase identifiers

### DIFF
--- a/configurations/GDScript.tmLanguage.json
+++ b/configurations/GDScript.tmLanguage.json
@@ -27,7 +27,7 @@
     { "include": "#any-method" },
     { "include": "#any-property" },
     { "include": "#extends" },
-    { "include": "#parscal_class" }
+    { "include": "#pascal_case_class" }
   ],
   "repository": {
     "comment": {
@@ -328,11 +328,11 @@
         }
       ]
     },
-    "parscal_class": {
+    "pascal_case_class": {
       "captures": {
         "1": { "name": "entity.name.type.class.gdscript" }
       },
-      "match": "([A-Z][a-zA-Z_0-9]*)"
+      "match": "\\b([A-Z][a-zA-Z_0-9]*)\\b"
     }
   }
 }


### PR DESCRIPTION
Currently, any occurrences of PascalCase identifiers (even as parts of other words) are recognized as classes.

This assumes snake_case convention for all methods and variables and makes it impossible to use camelCase. While this is the recommended GDScript style, the syntax highlighter should allow for different styles as long as it can do so unambiguously. This is already done for existing rules, but overridden by one rule with an overly general regex pattern.

This commit modifies the catch-all rule for the `parscal_class` group to only capture whole words.
For clarity, it renames `parscal_class` to `pascal_case_class`.

Before:
![before](https://user-images.githubusercontent.com/708488/71560057-4a9ba800-2a65-11ea-9e79-611f20348ed9.png)

After:
![after](https://user-images.githubusercontent.com/708488/71560060-4f605c00-2a65-11ea-902d-771d4674b51b.png)
