### PR TITLE
Add debugging support to the extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    
+    "prettier.useTabs": true,
+    "cSpell.ignoreWords": [
+        "debugadapter"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 1.1
+* Add the debugger to the extension
+
 ### 1.0.3
 * Fix hover popup position for VSCode 1.42+
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ experience as comfortable as possible:
 - Ctrl + click on a variable or method call to jump to its definition
 - Full documentation of the Godot Engine's API supported
 - Run a Godot project from VS Code
+- Debug your Godot project from VS Code with breakpoints, step-in, and call stack
 
 ![Showing the documentation on hover feature](img/godot-tools.png)
 
@@ -31,6 +32,16 @@ The extension adds a few entries to the VS Code Command Palette under "Godot Too
 - Open workspace with Godot editor
 - Run the workspace as a Godot project
 - List Godot's native classes
+
+## Debugger
+
+To configure the debugger:
+
+1. Open the command palette:
+2. `>Debug: Open launch.json`
+3. Select the Debug Godot configuration.
+4. Change any relevant settings.
+5. Press F5 to launch.
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "godot-tools",
 	"displayName": "godot-tools",
 	"icon": "icon.png",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "Tools for game development with godot game engine",
 	"repository": "https://github.com/godotengine/godot-vscode-plugin",
 	"author": "The Godot Engine community",
@@ -11,11 +11,13 @@
 		"vscode": "^1.33.0"
 	},
 	"categories": [
-		"Other"
+		"Other",
+		"Debuggers"
 	],
 	"activationEvents": [
 		"workspaceContains:project.godot",
-		"onLanguage:gdscript"
+		"onLanguage:gdscript",
+		"onDebug"
 	],
 	"main": "./out/extension.js",
 	"scripts": {
@@ -96,6 +98,75 @@
 				"language": "gdscript",
 				"path": "./configurations/snippets.json"
 			}
+		],
+		"debuggers": [
+			{
+				"type": "godot",
+				"label": "Godot Debug",
+				"program": "./out/debugger/debugAdapter.js",
+				"runtime": "node",
+				"configurationAttributes": {
+					"launch": {
+						"required": [
+							"project",
+							"port",
+							"address"
+						],
+						"properties": {
+							"project": {
+								"type": "string",
+								"description": "Absolute path to a directory with a project.godot file.",
+								"default": "${workspaceFolder}"
+							},
+							"port": {
+								"type": "number",
+								"description": "The port number for the Godot remote debugger to use.",
+								"default": 6007
+							},
+							"address": {
+								"type": "string",
+								"description": "The IP address for the Godot remote debugger to use.",
+								"default": "127.0.0.1"
+							},
+							"launch_game_instance": {
+								"type": "boolean",
+								"description": "Whether to launch an instance of the workspace's game, or wait for a debug session to connect.",
+								"default": true
+							}
+						}
+					}
+				},
+				"initialConfigurations": [
+					{
+						"name": "Godot",
+						"type": "godot",
+						"request": "launch",
+						"project": "${workspaceFolder}",
+						"port": 6007,
+						"address": "127.0.0.1",
+						"launch_game_instance": true
+					}
+				],
+				"configurationSnippets": [
+					{
+						"label": "Godot Debug: Launch",
+						"description": "A new configuration for debugging a Godot project.",
+						"body": {
+							"type": "godot",
+							"request": "launch",
+							"project": "${workspaceFolder}",
+							"port": 6007,
+							"address": "127.0.0.1",
+							"launch_game_instance": true
+						}
+					}
+				]
+			}
+		],
+		"breakpoints": [
+			{
+				"language": "gdscript"
+			}
 		]
 	},
 	"devDependencies": {
@@ -112,6 +183,9 @@
 		"global": "^4.4.0",
 		"marked": "^0.7.0",
 		"vscode-languageclient": "^5.2.1",
-		"ws": "^7.0.0"
+		"ws": "^7.0.0",
+		"await-notify": "^1.0.1",
+		"terminate": "^2.1.2",
+		"vscode-debugadapter": "^1.38.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"activationEvents": [
 		"workspaceContains:project.godot",
 		"onLanguage:gdscript",
-		"onDebug"
+		"onDebugResolve:godot"
 	],
 	"main": "./out/extension.js",
 	"scripts": {
@@ -167,7 +167,10 @@
 			{
 				"language": "gdscript"
 			}
-		]
+		],
+		"viewsContainers": {
+			
+		}
 	},
 	"devDependencies": {
 		"@types/marked": "^0.6.5",

--- a/src/debugger/communication/command.ts
+++ b/src/debugger/communication/command.ts
@@ -1,0 +1,60 @@
+export class Command {
+	private callback?: (
+		parameters: Array<boolean | number | string | {} | [] | undefined>
+	) => void | undefined;
+	private param_count = -1;
+	private param_count_callback?: (paramCount: number) => number;
+	private parameters: Array<
+		boolean | number | string | {} | [] | undefined
+	> = [];
+
+	public name: string;
+
+	constructor(
+		name: string,
+		parameters_fulfilled?: (parameters: Array<any>) => void | undefined,
+		modify_param_count?: (param_count: number) => number
+	) {
+		this.name = name;
+		this.callback = parameters_fulfilled;
+		this.param_count_callback = modify_param_count;
+	}
+
+	public append_parameters(
+		parameter: boolean | number | string | {} | [] | undefined
+	) {
+		if (this.param_count <= 0) {
+			this.param_count = parameter as number;
+			if(this.param_count === 0) {
+				if(this.callback) {
+					this.callback([]);
+				}
+			}
+			return;
+		}
+
+		this.parameters.push(parameter);
+
+		if (this.parameters.length === this.get_param_count()) {
+			if (this.callback) {
+				this.callback(this.parameters);
+			}
+		}
+	}
+
+	public chain() {
+		if (this.parameters.length === this.get_param_count()) {
+			this.parameters.length = 0;
+			this.param_count = -1;
+			return undefined;
+		} else {
+			return this;
+		}
+	}
+
+	protected get_param_count() {
+		return this.param_count_callback
+			? this.param_count_callback(this.param_count)
+			: this.param_count;
+	}
+}

--- a/src/debugger/communication/command_builder.ts
+++ b/src/debugger/communication/command_builder.ts
@@ -1,0 +1,53 @@
+import { Command } from "./command";
+import { VariantParser } from "../variant_parser";
+
+export class CommandBuilder {
+	private commands = new Map<string, Command>();
+	private current_command?: Command;
+	private dummy_command = new Command("---");
+
+	constructor() {}
+
+	public create_buffered_command(
+		command: string,
+		parser: VariantParser,
+		parameters?: any[]
+	): Buffer {
+		let command_array: any[] = [command];
+		if (parameters) {
+			parameters?.forEach(param => {
+				command_array.push(param);
+			});
+		}
+
+		let buffer = parser.encode_variant(command_array);
+		return buffer;
+	}
+
+	public parse_data(dataset: Array<any>): void {
+		while (dataset && dataset.length > 0) {
+			if (this.current_command) {
+				let next_command = this.current_command.chain();
+				if (next_command === this.current_command) {
+					this.current_command.append_parameters(dataset.shift());
+				} else {
+					this.current_command = next_command;
+				}
+			} else {
+				let data = dataset.shift();
+				let command = this.commands.get(data);
+				if (command) {
+					this.current_command = command;
+				} else {
+					console.log(`Unsupported command: ${data}. Skipping.`);
+					this.current_command = this.dummy_command;
+				}
+			}
+		}
+	}
+
+	public register_command(command: Command) {
+		let name = command.name;
+		this.commands.set(name, command);
+	}
+}

--- a/src/debugger/communication/godot_commands.ts
+++ b/src/debugger/communication/godot_commands.ts
@@ -1,0 +1,126 @@
+import { CommandBuilder } from "./command_builder";
+import { VariantParser } from "../variant_parser";
+import net = require("net");
+
+export class GodotCommands {
+	private builder: CommandBuilder;
+	private can_write = false;
+	private command_buffer: Buffer[] = [];
+	private connection: net.Socket | undefined;
+	private parser: VariantParser;
+
+	constructor(
+		builder: CommandBuilder,
+		parser: VariantParser,
+		connection?: net.Socket
+	) {
+		this.builder = builder;
+		this.parser = parser;
+		this.connection = connection;
+	}
+
+	public send_break_command() {
+		let buffer = this.builder.create_buffered_command("break", this.parser);
+		this.add_and_send(buffer);
+	}
+
+	public send_continue_Command() {
+		let buffer = this.builder.create_buffered_command("continue", this.parser);
+		this.add_and_send(buffer);
+	}
+
+	public send_inspect_object_command(object_id: number) {
+		let buffer = this.builder.create_buffered_command(
+			"inspect_object",
+			this.parser,
+			[object_id]
+		);
+
+		this.add_and_send(buffer);
+	}
+
+	public send_next_command() {
+		let buffer = this.builder.create_buffered_command("next", this.parser);
+		this.add_and_send(buffer);
+	}
+
+	public send_remove_breakpoint_command(file: string, line: number) {
+		this.send_breakpoint_command(false, file, line);
+	}
+
+	public send_set_breakpoint_command(file: string, line: number) {
+		this.send_breakpoint_command(true, file, line);
+	}
+
+	public send_skip_breakpoints_command(skip_breakpoints: boolean) {
+		let buffer = this.builder.create_buffered_command(
+			"set_skip_breakpoints",
+			this.parser,
+			[skip_breakpoints]
+		);
+
+		this.add_and_send(buffer);
+	}
+
+	public send_stack_dump_command() {
+		let buffer = this.builder.create_buffered_command(
+			"get_stack_dump",
+			this.parser
+		);
+
+		this.add_and_send(buffer);
+	}
+
+	public send_stack_frame_vars_command(level: number) {
+		let buffer = this.builder.create_buffered_command(
+			"get_stack_frame_vars",
+			this.parser,
+			[level]
+		);
+
+		this.add_and_send(buffer);
+	}
+
+	public send_step_command() {
+		let buffer = this.builder.create_buffered_command("step", this.parser);
+		this.add_and_send(buffer);
+	}
+
+	public set_can_write(value: boolean) {
+		this.can_write = value;
+		if (this.can_write) {
+			this.send_buffer();
+		}
+	}
+
+	public set_connection(connection: net.Socket) {
+		this.connection = connection;
+		this.can_write = true;
+	}
+
+	private add_and_send(buffer: Buffer) {
+		this.command_buffer.push(buffer);
+		this.send_buffer();
+	}
+
+	private send_breakpoint_command(set: boolean, file: string, line: number) {
+		let buffer = this.builder.create_buffered_command(
+			"breakpoint",
+			this.parser,
+			[file, line, set]
+		);
+		this.add_and_send(buffer);
+	}
+
+	private send_buffer() {
+		if (!this.connection) {
+			return;
+		}
+
+		while (this.can_write && this.command_buffer.length > 0) {
+			this.can_write = this.connection.write(
+				this.command_buffer.shift() as Buffer
+			);
+		}
+	}
+}

--- a/src/debugger/communication/server_controller.ts
+++ b/src/debugger/communication/server_controller.ts
@@ -227,6 +227,18 @@ export class ServerController {
 			this.connection = connection;
 			this.godot_commands?.set_connection(connection);
 
+			if (!launch_game_instance) {
+				this.breakpoints.forEach(bp => {
+					let path_to = path
+						.relative(this.project_path, bp.file)
+						.replace(/\\/g, "/");
+					this.godot_commands?.send_set_breakpoint_command(
+						`res://${path_to}`,
+						bp.line
+					);
+				});
+			}
+
 			connection.on("data", buffer => {
 				if (!this.parser || !this.builder) {
 					return;

--- a/src/debugger/communication/server_controller.ts
+++ b/src/debugger/communication/server_controller.ts
@@ -1,0 +1,393 @@
+const TERMINATE = require("terminate");
+import { EventEmitter } from "events";
+import net = require("net");
+import cp = require("child_process");
+import path = require("path");
+import { VariantParser } from "../variant_parser";
+import { Command } from "./command";
+import vscode = require("vscode");
+import { GodotCommands } from "./godot_commands";
+import { CommandBuilder } from "./command_builder";
+import { GodotBreakpoint, GodotStackFrame } from "../godot_debug_runtime";
+import utils = require("../../utils");
+
+export class ServerController {
+	private breakpoints: { file: string; line: number }[] = [];
+	private builder: CommandBuilder | undefined;
+	private connection: net.Socket | undefined;
+	private emitter: EventEmitter;
+	private exception = "";
+	private godot_commands: GodotCommands | undefined;
+	private godot_pid: number | undefined;
+	private inspected_callbacks: ((
+		class_name: string,
+		properties: any[]
+	) => void)[] = [];
+	private last_frame:
+		| { line: number; file: string; function: string }
+		| undefined;
+	private output_channel: vscode.OutputChannel | undefined;
+	private parser: VariantParser | undefined;
+	private project_path: string;
+	private scope_callbacks: ((
+		stack_level: number,
+		stack_files: string[],
+		scopes: {
+			locals: { name: string; value: any }[];
+			members: { name: string; value: any }[];
+			globals: { name: string; value: any }[];
+		}
+	) => void)[] = [];
+	private server: net.Server | undefined;
+	private stack_count = 0;
+	private stack_files: string[] = [];
+	private stack_level = 0;
+	private stepping_out = false;
+
+	constructor(
+		event_emitter: EventEmitter,
+		output_channel?: vscode.OutputChannel
+	) {
+		this.emitter = event_emitter;
+		this.output_channel = output_channel;
+	}
+
+	public break() {
+		this.godot_commands?.send_break_command();
+	}
+
+	public continue() {
+		this.godot_commands?.send_continue_Command();
+	}
+
+	public get_scope(
+		level: number,
+		callback?: (
+			stack_level: number,
+			stack_files: string[],
+			scopes: {
+				locals: { name: string; value: any }[];
+				members: { name: string; value: any }[];
+				globals: { name: string; value: any }[];
+			}
+		) => void
+	) {
+		this.godot_commands?.send_stack_frame_vars_command(level);
+		this.stack_level = level;
+		if (callback) {
+			this.scope_callbacks.push(callback);
+		}
+	}
+
+	public inspect_object(
+		id: number,
+		inspected: (class_name: string, properties: any[]) => void
+	) {
+		this.inspected_callbacks.push(inspected);
+		this.godot_commands?.send_inspect_object_command(id);
+	}
+
+	public next() {
+		this.godot_commands?.send_next_command();
+	}
+
+	public remove_breakpoint(path_to: string, line: number) {
+		this.breakpoints.splice(
+			this.breakpoints.findIndex(bp => bp.file === path_to && bp.line === line),
+			1
+		);
+		this.godot_commands?.send_remove_breakpoint_command(path_to, line);
+	}
+
+	public set_breakpoint(path_to: string, line: number) {
+		this.breakpoints.push({ file: path_to, line: line });
+		this.godot_commands?.send_set_breakpoint_command(path_to, line);
+	}
+
+	public start(
+		project_path: string,
+		port: number,
+		address: string,
+		launch_game_instance?: boolean,
+		breakpoints?: GodotBreakpoint[]
+	) {
+		this.builder = new CommandBuilder();
+		this.parser = new VariantParser();
+		this.project_path = project_path.replace(/\\/g, "/");
+		if (this.project_path.match(/^[A-Z]:\//)) {
+			this.project_path =
+				this.project_path[0].toLowerCase() + this.project_path.slice(1);
+		}
+		this.godot_commands = new GodotCommands(this.builder, this.parser);
+
+		if (breakpoints) {
+			this.breakpoints = breakpoints.map(bp => {
+				return { file: bp.file, line: bp.line };
+			});
+		}
+
+		this.builder.register_command(new Command("debug_exit", params => {}));
+
+		this.builder.register_command(
+			new Command("debug_enter", params => {
+				let reason = params[1];
+				if (reason !== "Breakpoint") {
+					this.exception = params[1];
+				} else {
+					this.exception = "";
+				}
+				this.godot_commands?.send_stack_dump_command();
+			})
+		);
+
+		this.builder.register_command(
+			new Command("stack_dump", params => {
+				let frames: Map<string, any>[] = params;
+				this.trigger_breakpoint(
+					frames.map((sf, i) => {
+						return {
+							id: i,
+							thread_id: sf.get("id"),
+							file: sf.get("file"),
+							function: sf.get("function"),
+							line: sf.get("line")
+						};
+					})
+				);
+			})
+		);
+
+		this.builder.register_command(
+			new Command("output", params => {
+				params.forEach(line => {
+					this.output_channel?.appendLine(line);
+				});
+			})
+		);
+
+		this.builder.register_command(
+			new Command("error", params => {
+				params.forEach(param => {});
+			})
+		);
+
+		this.builder.register_command(new Command("performance", params => {}));
+
+		this.builder.register_command(
+			new Command("message:inspect_object", params => {
+				let id = params[0];
+				let class_name = params[1];
+				let properties = params[2];
+
+				let callback = this.inspected_callbacks.shift();
+				if (callback) {
+					callback(class_name, properties);
+				}
+			})
+		);
+
+		this.builder.register_command(
+			new Command("stack_frame_vars", params => {
+				let locals: any[] = [];
+				let members: any[] = [];
+				let globals: any[] = [];
+
+				let local_count = (params[0] as number) * 2;
+				let member_count = params[1 + local_count] * 2;
+				let global_count = params[2 + local_count + member_count] * 2;
+
+				if (local_count > 0) {
+					locals = params.slice(1, 1 + local_count);
+				}
+				if (member_count > 0) {
+					members = params.slice(
+						2 + local_count,
+						2 + local_count + member_count
+					);
+				}
+				if (global_count > 0) {
+					globals = params.slice(
+						3 + local_count + member_count,
+						3 + local_count + member_count + global_count
+					);
+				}
+
+				this.pumpScope(
+					{
+						locals: locals,
+						members: members,
+						globals: globals
+					},
+					project_path
+				);
+			})
+		);
+
+		this.server = net.createServer(connection => {
+			this.connection = connection;
+			this.godot_commands?.set_connection(connection);
+
+			connection.on("data", buffer => {
+				if (!this.parser || !this.builder) {
+					return;
+				}
+
+				let len = buffer.byteLength;
+				let offset = 0;
+				do {
+					let data = this.parser.get_buffer_dataset(buffer, offset);
+					let data_offset = data[0] as number;
+					offset += data_offset;
+					len -= data_offset;
+					this.builder.parse_data(data.slice(1));
+				} while (len > 0);
+			});
+
+			connection.on("close", hadError => {
+				if (hadError) {
+					this.send_event("terminated");
+				}
+			});
+
+			connection.on("end", () => {
+				this.send_event("terminated");
+			});
+
+			connection.on("error", error => {
+				console.error(error);
+			});
+
+			connection.on("drain", () => {
+				connection.resume();
+				this.godot_commands?.set_can_write(true);
+			});
+		});
+
+		this.server?.listen(port, address);
+
+		if (launch_game_instance) {
+			let godot_path = utils.get_configuration(
+				"editor_path",
+				"godot"
+			) as string;
+			let executable_line = `${godot_path} --path ${project_path} --remote-debug ${address}:${port}`;
+			executable_line += this.build_breakpoint_string(
+				breakpoints,
+				project_path
+			);
+			let godot_exec = cp.exec(executable_line);
+			this.godot_pid = godot_exec.pid;
+		}
+	}
+
+	public step() {
+		this.godot_commands?.send_step_command();
+	}
+
+	public step_out() {
+		this.stepping_out = true;
+		this.next();
+	}
+
+	public stop() {
+		this.connection?.end(() => {
+			this.server?.close();
+			if (this.godot_pid) {
+				TERMINATE(this.godot_pid, (error: string | undefined) => {
+					if (error) {
+						console.error(error);
+					}
+				});
+			}
+		});
+		this.send_event("terminated");
+	}
+
+	private build_breakpoint_string(
+		breakpoints: GodotBreakpoint[],
+		project: string
+	): string {
+		let output = "";
+		if (breakpoints.length > 0) {
+			output += " --breakpoints ";
+
+			breakpoints.forEach(bp => {
+				let relative_path = path.relative(project, bp.file).replace(/\\/g, "/");
+				if (relative_path.length !== 0) {
+					output += `res://${relative_path}:${bp.line},`;
+				}
+			});
+			output = output.slice(0, -1);
+		}
+
+		return output;
+	}
+
+	private pumpScope(
+		scopes: {
+			locals: any[];
+			members: any[];
+			globals: any[];
+		},
+		projectPath: string
+	) {
+		if (this.scope_callbacks.length > 0) {
+			let cb = this.scope_callbacks.shift();
+			if (cb) {
+				let stack_files = this.stack_files.map(sf => {
+					return sf.replace("res://", `${projectPath}/`);
+				});
+				cb(this.stack_level, stack_files, scopes);
+			}
+		}
+	}
+
+	private send_event(event: string, ...args: any[]) {
+		setImmediate(_ => {
+			this.emitter.emit(event, ...args);
+		});
+	}
+
+	private trigger_breakpoint(stack_frames: GodotStackFrame[]) {
+		let continue_stepping = false;
+		let stack_count = stack_frames.length;
+
+		let file = stack_frames[0].file.replace("res://", `${this.project_path}/`);
+		let line = stack_frames[0].line;
+
+		if (this.stepping_out) {
+			let breakpoint = this.breakpoints.find(
+				k => k.file === file && k.line === line
+			);
+			if (!breakpoint) {
+				if (this.stack_count > 1) {
+					continue_stepping = this.stack_count === stack_count;
+				} else {
+					let file_same = stack_frames[0].file === this.last_frame.file;
+					let func_same = stack_frames[0].function === this.last_frame.function;
+					let line_greater = stack_frames[0].line >= this.last_frame.line;
+
+					continue_stepping = file_same && func_same && line_greater;
+				}
+			}
+		}
+		this.stack_count = stack_count;
+		this.last_frame = stack_frames[0];
+
+		if (continue_stepping) {
+			this.next();
+			return;
+		}
+
+		this.stepping_out = false;
+
+		this.stack_files = stack_frames.map(sf => {
+			return sf.file;
+		});
+		if (this.exception.length === 0) {
+			this.send_event("stopOnBreakpoint", stack_frames);
+		} else {
+			this.send_event("stopOnException", stack_frames, this.exception);
+		}
+	}
+}

--- a/src/debugger/debug_adapter.ts
+++ b/src/debugger/debug_adapter.ts
@@ -1,0 +1,3 @@
+import { GodotDebugSession } from "./godot_debug";
+
+GodotDebugSession.run(GodotDebugSession);

--- a/src/debugger/debugger_context.ts
+++ b/src/debugger/debugger_context.ts
@@ -10,12 +10,10 @@ import {
 	DebugSession,
 	CancellationToken,
 	ProviderResult,
-	window,
-	OutputChannel
+	window
 } from "vscode";
 import { GodotDebugSession } from "./godot_debug";
 import fs = require("fs");
-import { VersionedTextDocumentIdentifier } from "vscode-languageclient";
 
 export function register_debugger(context: ExtensionContext) {
 	const PROVIDER = new GodotConfigurationProvider();

--- a/src/debugger/debugger_context.ts
+++ b/src/debugger/debugger_context.ts
@@ -1,0 +1,81 @@
+import {
+	ExtensionContext,
+	debug,
+	DebugConfigurationProvider,
+	WorkspaceFolder,
+	DebugAdapterInlineImplementation,
+	DebugAdapterDescriptorFactory,
+	DebugConfiguration,
+	DebugAdapterDescriptor,
+	DebugSession,
+	CancellationToken,
+	ProviderResult,
+	window,
+	OutputChannel
+} from "vscode";
+import { GodotDebugSession } from "./godot_debug";
+import fs = require("fs");
+import { VersionedTextDocumentIdentifier } from "vscode-languageclient";
+
+export function register_debugger(context: ExtensionContext) {
+	const PROVIDER = new GodotConfigurationProvider();
+	context.subscriptions.push(
+		debug.registerDebugConfigurationProvider("godot", PROVIDER)
+	);
+
+	let factory = new GodotDebugAdapterFactory();
+	context.subscriptions.push(
+		debug.registerDebugAdapterDescriptorFactory("godot", factory)
+	);
+
+	context.subscriptions.push(factory);
+}
+
+class GodotConfigurationProvider implements DebugConfigurationProvider {
+	public resolveDebugConfiguration(
+		folder: WorkspaceFolder | undefined,
+		config: DebugConfiguration,
+		token?: CancellationToken
+	): ProviderResult<DebugConfiguration> {
+		if (!config.type && !config.request && !config.name) {
+			const editor = window.activeTextEditor;
+			if (editor && fs.existsSync(`${folder}/project.godot`)) {
+				config.type = "godot";
+				config.name = "Debug Godot";
+				config.request = "launch";
+				config.project = "${workspaceFolder}";
+				config.port = 6007;
+				config.address = "127.0.0.1";
+				config.launch_game_instance = true;
+			}
+		}
+
+		if (!config.project) {
+			return window
+				.showInformationMessage(
+					"Cannot find a project.godot in active workspace."
+				)
+				.then(() => {
+					return undefined;
+				});
+		}
+
+		return config;
+	}
+}
+
+class GodotDebugAdapterFactory implements DebugAdapterDescriptorFactory {
+	private session: GodotDebugSession | undefined;
+
+	public createDebugAdapterDescriptor(
+		session: DebugSession
+	): ProviderResult<DebugAdapterDescriptor> {
+		this.session = new GodotDebugSession();
+		return new DebugAdapterInlineImplementation(this.session);
+	}
+
+	public dispose() {
+		this.session.dispose();
+		this.session = undefined;
+	}
+}

--- a/src/debugger/godot_debug.ts
+++ b/src/debugger/godot_debug.ts
@@ -1,0 +1,779 @@
+import {
+	LoggingDebugSession,
+	InitializedEvent,
+	TerminatedEvent,
+	StoppedEvent,
+	Thread,
+	Source,
+	Breakpoint
+} from "vscode-debugadapter";
+import {
+	window,
+	OutputChannel
+} from "vscode";
+import { DebugProtocol } from "vscode-debugprotocol";
+import { GodotDebugRuntime, GodotStackFrame } from "./godot_debug_runtime";
+const { Subject } = require("await-notify");
+import fs = require("fs");
+import { VariableScope } from "./variable_scope";
+
+interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+	address: string;
+	launch_game_instance: boolean;
+	port: number;
+	project: string;
+}
+
+export class GodotDebugSession extends LoggingDebugSession {
+	private static MAIN_THREAD_ID = 0;
+
+	private configuration_done = new Subject();
+	private excepted = false;
+	private inspect_callback: (() => void) | undefined;
+	private inspected: number[] = [];
+	private last_frames: GodotStackFrame[] = [];
+	private runtime: GodotDebugRuntime;
+	private scope_id = 1;
+	private scopes = new Map<number, Map<string, VariableScope[]>>();
+	private thread_ids: number[] = [];
+	private have_scopes: (() => void)[] = [];
+	private current_stack_level = 0;
+	private output_channel: OutputChannel;
+
+	public constructor() {
+		super();
+		
+		this.output_channel = window.createOutputChannel("Godot");
+
+		this.setDebuggerLinesStartAt1(false);
+		this.setDebuggerColumnsStartAt1(false);
+
+		this.runtime = new GodotDebugRuntime();
+
+		this.runtime.on("stopOnBreakpoint", frames => {
+			this.last_frames = frames;
+			this.sendEvent(
+				new StoppedEvent("breakpoint", GodotDebugSession.MAIN_THREAD_ID)
+			);
+		});
+
+		this.runtime.on("stopOnException", (frames, exception) => {
+			this.last_frames = frames;
+			this.sendEvent(
+				new StoppedEvent(
+					"exception",
+					GodotDebugSession.MAIN_THREAD_ID,
+					exception
+				)
+			);
+		});
+
+		this.runtime.on("terminated", () => {
+			this.sendEvent(new TerminatedEvent(false));
+		});
+	}
+	
+	public dispose() {
+		this.output_channel.dispose();
+	}
+
+	protected configurationDoneRequest(
+		response: DebugProtocol.ConfigurationDoneResponse,
+		args: DebugProtocol.ConfigurationDoneArguments
+	): void {
+		super.configurationDoneRequest(response, args);
+
+		this.configuration_done.notify();
+	}
+
+	protected continueRequest(
+		response: DebugProtocol.ContinueResponse,
+		args: DebugProtocol.ContinueArguments
+	): void {
+		if (this.excepted) {
+			return;
+		}
+		this.scopes.clear();
+		
+		response.body = {
+			allThreadsContinued: true
+		};
+
+		this.runtime.continue();
+
+		this.sendResponse(response);
+	}
+
+	protected evaluateRequest(
+		response: DebugProtocol.EvaluateResponse,
+		args: DebugProtocol.EvaluateArguments
+	) {
+		this.have_scopes.push(() => {
+			if(args.expression.match(/[^a-zA-Z0-9_\[\]\.]/g)) {
+				response.body = {
+					result: "not supported",
+					variablesReference: 0
+				};
+				this.sendResponse(response);
+				return;
+			}
+			
+			let is_self = args.expression.match(/^self\./);
+			let expression = args.expression
+			.replace(/[\[\]]/g, ".")
+				.replace(/\.$/, "")
+				.replace(/^self./, "");
+			let variable: { name: string; value: any } | undefined;
+			let scope_keys = Array.from(this.scopes.get(this.current_stack_level).keys());
+			let variable_id = -1;
+			for (let i = 0; i < scope_keys.length; ++i) {
+				let scopes = this.scopes.get(this.current_stack_level).get(scope_keys[i]);
+				
+				for (let l = is_self ? 1 : 0; l < 3; ++l) {
+					variable_id = scopes[l].get_id_for(expression);
+					if (variable_id !== -1) {
+						variable = scopes[l].get_variable(variable_id);
+						break;
+					}
+				}
+
+				if (variable) {
+					break;
+				}
+			}
+
+			if (!variable) {
+				response.body = {
+					result: "not available",
+					variablesReference: 0
+				};
+				
+				this.sendResponse(response);
+				return;
+			}
+
+			let value_type_pair = this.get_stringified_value_pair(variable.value);
+
+			response.body = {
+				result: value_type_pair.value,
+				type: value_type_pair.type,
+				variablesReference: variable_id
+			};
+
+			this.sendResponse(response);
+		});
+		if (this.scopes.size > 0 && this.scopes.get(this.current_stack_level).size > 0) {
+			this.have_scopes.shift()();
+		}
+	}
+
+	protected initializeRequest(
+		response: DebugProtocol.InitializeResponse,
+		args: DebugProtocol.InitializeRequestArguments
+	): void {
+		response.body = response.body || {};
+
+		response.body.supportsConfigurationDoneRequest = true;
+		response.body.supportsTerminateRequest = true;
+
+		response.body.supportsEvaluateForHovers = false;
+
+		response.body.supportsStepBack = false;
+		response.body.supportsGotoTargetsRequest = false;
+
+		response.body.supportsCancelRequest = false;
+
+		response.body.supportsCompletionsRequest = false;
+
+		response.body.supportsFunctionBreakpoints = false;
+		response.body.supportsDataBreakpoints = false;
+		response.body.supportsBreakpointLocationsRequest = false;
+		response.body.supportsConditionalBreakpoints = false;
+		response.body.supportsHitConditionalBreakpoints = false;
+
+		response.body.supportsLogPoints = false;
+
+		response.body.supportsModulesRequest = false;
+
+		response.body.supportsReadMemoryRequest = false;
+
+		response.body.supportsRestartFrame = false;
+		response.body.supportsRestartRequest = false;
+
+		response.body.supportsSetExpression = false;
+
+		response.body.supportsSetVariable = false;
+		response.body.supportsStepInTargetsRequest = false;
+
+		response.body.supportsTerminateThreadsRequest = false;
+
+		this.sendResponse(response);
+
+		this.sendEvent(new InitializedEvent());
+	}
+
+	protected async launchRequest(
+		response: DebugProtocol.LaunchResponse,
+		args: LaunchRequestArguments
+	) {
+		await this.configuration_done.wait(1000);
+		this.excepted = false;
+		this.runtime.start(
+			args.project,
+			args.address,
+			args.port,
+			args.launch_game_instance,
+			this.output_channel
+		);
+		this.sendResponse(response);
+	}
+
+	protected nextRequest(
+		response: DebugProtocol.NextResponse,
+		args: DebugProtocol.NextArguments
+	): void {
+		if (this.excepted) {
+			return;
+		}
+		this.scopes.clear();
+		this.runtime.next();
+		this.sendResponse(response);
+	}
+
+	protected pauseRequest(
+		response: DebugProtocol.PauseResponse,
+		args: DebugProtocol.PauseArguments
+	): void {
+		if (this.excepted) {
+			return;
+		}
+		this.runtime.break();
+		this.sendResponse(response);
+	}
+
+	protected scopesRequest(
+		response: DebugProtocol.ScopesResponse,
+		args: DebugProtocol.ScopesArguments
+	): void {
+		this.runtime.getScope(args.frameId, (stack_level, stack_files, scopes) => {
+			this.scope_id = 1;
+			this.current_stack_level = stack_level;
+			let file = stack_files[stack_level];
+
+			let file_scopes: VariableScope[] = [];
+
+			let local_scope = new VariableScope(this.scope_id++);
+			let member_scope = new VariableScope(this.scope_id++);
+			let global_scope = new VariableScope(this.scope_id++);
+
+			file_scopes.push(local_scope);
+			file_scopes.push(member_scope);
+			file_scopes.push(global_scope);
+			
+			this.scopes.clear();
+			this.scopes.set(stack_level, new Map<string, VariableScope[]>([[file, file_scopes]]));
+
+			let out_local_scope: DebugProtocol.Scope = {
+				name: "Locals",
+				namedVariables: scopes.locals.length / 2,
+				presentationHint: "locals",
+				expensive: false,
+				variablesReference: local_scope.id
+			};
+
+			for (let i = 0; i < scopes.locals.length; i += 2) {
+				let name = scopes.locals[i];
+				let value = scopes.locals[i + 1];
+
+				this.drill_scope(local_scope, {
+					name: name,
+					value: value ? value : undefined
+				});
+			}
+
+			let out_member_scope: DebugProtocol.Scope = {
+				name: "Members",
+				namedVariables: scopes.members.length / 2,
+				presentationHint: "locals",
+				expensive: false,
+				variablesReference: member_scope.id
+			};
+
+			for (let i = 0; i < scopes.members.length; i += 2) {
+				let name = scopes.members[i];
+				let value = scopes.members[i + 1];
+
+				this.drill_scope(member_scope, { name: name, value: value });
+			}
+
+			let out_global_scope: DebugProtocol.Scope = {
+				name: "Globals",
+				namedVariables: scopes.globals.length / 2,
+				presentationHint: "locals",
+				expensive: false,
+				variablesReference: global_scope.id
+			};
+
+			for (let i = 0; i < scopes.globals.length; i += 2) {
+				let name = scopes.globals[i];
+				let value = scopes.globals[i + 1];
+
+				this.drill_scope(global_scope, { name: name, value: value });
+			}
+
+			response.body = {
+				scopes: [out_local_scope, out_member_scope, out_global_scope]
+			};
+
+			if (this.inspected.length === 0) {
+				while (this.have_scopes.length > 0) {
+					this.have_scopes.shift()();
+				}
+				this.sendResponse(response);
+			} else {
+				this.inspect_callback = () => {
+					while(this.have_scopes.length > 0) {
+						this.have_scopes.shift()();
+					}
+					this.sendResponse(response);
+				};
+			}
+		});
+	}
+
+	protected setBreakPointsRequest(
+		response: DebugProtocol.SetBreakpointsResponse,
+		args: DebugProtocol.SetBreakpointsArguments
+	): void {
+		let path = (args.source.path as string).replace(/\\/g, "/");
+		let client_lines = args.lines || [];
+
+		if (fs.existsSync(path)) {
+			let bps = this.runtime.get_breakpoints(path);
+			let bp_lines = bps.map(bp => bp.line);
+
+			bps.forEach(bp => {
+				if (client_lines.indexOf(bp.line) === -1) {
+					this.runtime.remove_breakpoint(path, bp.line);
+				}
+			});
+			client_lines.forEach(l => {
+				if (bp_lines.indexOf(l) === -1) {
+					this.runtime.set_breakpoint(path, l);
+				}
+			});
+
+			bps = this.runtime.get_breakpoints(path);
+
+			response.body = {
+				breakpoints: bps.map(bp => {
+					return new Breakpoint(
+						true,
+						bp.line,
+						1,
+						new Source(bp.file.split("/").reverse()[0], bp.file, bp.id)
+					);
+				})
+			};
+
+			this.sendResponse(response);
+		}
+	}
+
+	protected setExceptionBreakPointsRequest(
+		response: DebugProtocol.SetExceptionBreakpointsResponse,
+		args: DebugProtocol.SetExceptionBreakpointsArguments
+	) {
+		this.excepted = true;
+		this.sendResponse(response);
+	}
+
+	protected stackTraceRequest(
+		response: DebugProtocol.StackTraceResponse,
+		args: DebugProtocol.StackTraceArguments
+	): void {
+		if (this.last_frames) {
+			response.body = {
+				totalFrames: this.last_frames.length,
+				stackFrames: this.last_frames.map(sf => {
+					return {
+						id: sf.id,
+						name: sf.function,
+						line: sf.line,
+						column: 1,
+						source: new Source(
+							sf.file,
+							`${this.runtime.getProject()}/${sf.file.replace("res://", "")}`
+						)
+					};
+				})
+			};
+		}
+		this.sendResponse(response);
+	}
+
+	protected stepInRequest(
+		response: DebugProtocol.StepInResponse,
+		args: DebugProtocol.StepInArguments
+	) {
+		if (this.excepted) {
+			return;
+		}
+		this.scopes.clear();
+		this.runtime.step();
+		this.sendResponse(response);
+	}
+
+	protected stepOutRequest(
+		response: DebugProtocol.StepOutResponse,
+		args: DebugProtocol.StepOutArguments
+	) {
+		if (this.excepted) {
+			return;
+		}
+
+		this.runtime.step_out();
+
+		this.sendResponse(response);
+	}
+
+	protected terminateRequest(
+		response: DebugProtocol.TerminateResponse,
+		args: DebugProtocol.TerminateArguments
+	) {
+		this.runtime.terminate();
+		this.sendResponse(response);
+	}
+
+	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+		response.body = {
+			threads: [new Thread(GodotDebugSession.MAIN_THREAD_ID, "thread_1")]
+		};
+		this.sendResponse(response);
+	}
+
+	protected async variablesRequest(
+		response: DebugProtocol.VariablesResponse,
+		args: DebugProtocol.VariablesArguments,
+		request?: DebugProtocol.Request
+	) {
+		let out_id = args.variablesReference;
+		let files = Array.from(this.scopes.get(this.current_stack_level).keys());
+
+		let out_scope_object = this.get_variable_scope(files, out_id);
+		let is_scope = out_scope_object.isScope;
+		let out_scope = out_scope_object.scope;
+
+		if (out_scope) {
+			if (is_scope) {
+				let var_ids = out_scope.get_variable_ids();
+				response.body = {
+					variables: this.parse_scope(var_ids, out_scope)
+				};
+			} else {
+				let variable = out_scope.get_variable(out_id);
+				if (variable) {
+					let sub_variables = out_scope.get_sub_variables_for(out_id);
+					if (sub_variables) {
+						let ids = out_scope.get_variable_ids();
+						let path_to = variable.name;
+						response.body = {
+							variables: []
+						};
+
+						if (args.filter === "indexed") {
+							let count = args.count || 0;
+							for (let i = 0; i < count; i++) {
+								let name = `${path_to}.${i}`;
+								let id_index = ids.findIndex(id => {
+									let variable = out_scope?.get_variable(id);
+									return variable && name === variable.name;
+								});
+
+								response.body.variables.push(
+									this.get_variable_response(
+										name,
+										variable.value[i],
+										ids[id_index]
+									)
+								);
+							}
+						} else {
+							sub_variables.forEach(sv => {
+								let name = sv.name;
+								let id_index = ids.findIndex(id => {
+									let variable = out_scope?.get_variable(id);
+									return variable && name === variable.name;
+								});
+
+								response.body.variables.push(
+									this.get_variable_response(name, sv.value, ids[id_index])
+								);
+							});
+						}
+					} else {
+						response.body = {
+							variables: [
+								this.get_variable_response(
+									variable.name,
+									variable.value,
+									0,
+									true
+								)
+							]
+						};
+					}
+				} else {
+					response.body = { variables: [] };
+				}
+			}
+
+			this.sendResponse(response);
+		}
+	}
+
+	private drill_scope(scope: VariableScope, variable: any) {
+		let id = scope.get_id_for(variable.name);
+		if (id === -1) {
+			id = this.scope_id++;
+		}
+		scope.set_variable(variable.name, variable.value, id);
+		if (Array.isArray(variable.value) || variable.value instanceof Map) {
+			let length = 0;
+			let values: any[];
+			if (variable.value instanceof Map) {
+				length = variable.value.size;
+				let keys = Array.from(variable.value.keys());
+				values = keys.map(key => {
+					let value = variable.value.get(key);
+					let stringified_key = this.get_stringified_value_pair(key).value;
+
+					return {
+						__type__: "Pair",
+						key: key,
+						value: value,
+						__render__: () => stringified_key
+					};
+				});
+				variable.value = values;
+			} else {
+				length = variable.value.length;
+				values = variable.value;
+			}
+			for (let i = 0; i < length; i++) {
+				let name = `${variable.name}.${i}`;
+				scope.set_sub_variable_for(id, name, values[i]);
+				this.drill_scope(scope, {
+					name: name,
+					value: values[i]
+				});
+			}
+		} else if (typeof variable.value === "object") {
+			if (variable.value.__type__ && variable.value.__type__ === "Object") {
+				if (this.inspected.indexOf(id) === -1) {
+					this.inspected.push(id);
+					this.runtime.inspect_object(
+						variable.value.id,
+						(class_name, properties) => {
+							variable.value.__type__ = class_name;
+							let start_index = properties.findIndex(p => {
+								return p[0] === class_name;
+							});
+							variable.value.__render__ = () => `${class_name}`;
+							let relevant_properties = properties
+								.slice(start_index + 1)
+								.filter(p => {
+									if (!p[5]) {
+										return Number.isInteger(p[5]);
+									}
+
+									return true;
+								});
+							relevant_properties.forEach(p => {
+								let sub_name = `${variable.name}.${p[0]}`;
+								scope.set_sub_variable_for(id, sub_name, p[5]);
+								this.drill_scope(scope, { name: sub_name, value: p[5] });
+							});
+
+							this.inspected.splice(
+								this.inspected.indexOf(variable.value.id),
+								1
+							);
+
+							if (this.inspected.length === 0 && this.inspect_callback) {
+								this.inspect_callback();
+							}
+						}
+					);
+				}
+			} else {
+				for (const PROP in variable.value) {
+					if (PROP !== "__type__" && PROP !== "__render__") {
+						let name = `${variable.name}.${PROP}`;
+						scope.set_sub_variable_for(id, name, variable.value[PROP]);
+						this.drill_scope(scope, {
+							name: name,
+							value: variable.value[PROP]
+						});
+					}
+				}
+			}
+		}
+	}
+
+	private get_stringified_value_pair(var_value: any) {
+		let type = "";
+		let value = "";
+		let skip_id = true;
+		if (typeof var_value === "number" && !Number.isInteger(var_value)) {
+			value = String(+Number.parseFloat(no_exponents(var_value)).toFixed(4));
+			type = "Float";
+		} else if (Array.isArray(var_value)) {
+			value = "Array";
+			type = "Array";
+			skip_id = false;
+		} else if (var_value instanceof Map) {
+			value = "Dictionary";
+			type = "Dictionary";
+			skip_id = false;
+		} else if (typeof var_value === "object") {
+			skip_id = false;
+			if (var_value.__type__) {
+				if (var_value.__type__ === "Object") {
+					skip_id = true;
+				}
+				if (var_value.__render__) {
+					value = var_value.__render__();
+				} else {
+					value = var_value.__type__;
+				}
+				type = var_value.__type__;
+			} else {
+				value = "Object";
+			}
+		} else {
+			if (var_value) {
+				if (Number.isInteger(var_value)) {
+					type = "Int";
+					value = `${var_value}`;
+				} else if (typeof var_value === "string") {
+					type = "String";
+					value = String(var_value);
+				} else {
+					type = "unknown";
+					value = `${var_value}`;
+				}
+			} else {
+				if (Number.isInteger(var_value)) {
+					type = "Int";
+					value = "0";
+				} else {
+					type = "unknown";
+					value = "null";
+				}
+			}
+		}
+
+		return { type: type, value: value, skip_id: skip_id };
+	}
+
+	private get_variable_response(
+		var_name: string,
+		var_value: any,
+		id: number,
+		skip_sub_var?: boolean
+	) {
+		let value = "";
+		let ref_id = 0;
+		let array_count = 0;
+		let type = "";
+		if (!skip_sub_var) {
+			let output = this.get_stringified_value_pair(var_value);
+
+			value = output.value;
+			type = output.type;
+			ref_id = output.skip_id ? 0 : id;
+		}
+		return {
+			name: var_name.replace(/([a-zA-Z0-9_]+?\.)*/g, ""),
+			value: value,
+			variablesReference: ref_id,
+			indexedVariables: array_count,
+			type: type
+		};
+	}
+
+	private get_variable_scope(files: string[], scope_id: number) {
+		let out_scope: VariableScope | undefined;
+		let is_scope = false;
+		for (let i = 0; i < files.length; i++) {
+			let file = files[i];
+
+			let scopes = this.scopes.get(this.current_stack_level).get(file);
+			if (scopes) {
+				let index = scopes.findIndex(s => {
+					return s.id === scope_id;
+				});
+				if (index !== -1) {
+					out_scope = scopes[index];
+					is_scope = true;
+					break;
+				} else {
+					for (let l = 0; l < scopes.length; l++) {
+						let scope = scopes[l];
+						let ids = scope.get_variable_ids();
+						for (let k = 0; k < ids.length; k++) {
+							let id = ids[k];
+							if (scope_id === id) {
+								out_scope = scope;
+								is_scope = false;
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return { isScope: is_scope, scope: out_scope };
+	}
+
+	private parse_scope(var_ids: number[], out_scope: VariableScope) {
+		let output: DebugProtocol.Variable[] = [];
+		var_ids.forEach(id => {
+			let variable = out_scope?.get_variable(id);
+			if (variable && variable.name.indexOf(".") === -1) {
+				output.push(
+					this.get_variable_response(variable.name, variable.value, id)
+				);
+			}
+		});
+
+		return output;
+	}
+}
+
+function no_exponents(value: number): string {
+	let data = String(value).split(/[eE]/);
+	if (data.length === 1) {
+		return data[0];
+	}
+
+	let z = "",
+		sign = value < 0 ? "-" : "";
+	let str = data[0].replace(".", "");
+	let mag = Number(data[1]) + 1;
+
+	if (mag < 0) {
+		z = sign + "0.";
+		while (mag++) {
+			z += "0";
+		}
+		return z + str.replace(/^\-/, "");
+	}
+	mag -= str.length;
+	while (mag--) {
+		z += 0;
+	}
+	return str + z;
+}

--- a/src/debugger/godot_debug_runtime.ts
+++ b/src/debugger/godot_debug_runtime.ts
@@ -1,0 +1,158 @@
+import vscode = require("vscode");
+import { EventEmitter } from "events";
+import { ServerController } from "./communication/server_controller";
+
+export interface GodotBreakpoint {
+	file: string;
+	id: number;
+	line: number;
+}
+
+export interface GodotStackFrame {
+	file: string;
+	function: string;
+	id: number;
+	line: number;
+}
+
+export class GodotDebugRuntime extends EventEmitter {
+	private breakpointId = 0;
+	private breakpoints = new Map<string, GodotBreakpoint[]>();
+	private out: vscode.OutputChannel | undefined;
+	private paused = false;
+	private project = "";
+	private serverController: ServerController | undefined;
+
+	constructor() {
+		super();
+	}
+
+	public break() {
+		if (this.paused) {
+			this.serverController?.continue();
+		} else {
+			this.serverController?.break();
+		}
+	}
+
+	public continue() {
+		this.serverController?.continue();
+	}
+
+	public getProject(): string {
+		return this.project;
+	}
+
+	public getScope(
+		level: number,
+		callback?: (
+			stackLevel: number,
+			stackFiles: string[],
+			scopes: {
+				locals: { name: string; value: any }[];
+				members: { name: string; value: any }[];
+				globals: { name: string; value: any }[];
+			}
+		) => void
+	) {
+		this.serverController?.get_scope(level, callback);
+	}
+
+	public get_breakpoints(path: string): GodotBreakpoint[] {
+		let bps = this.breakpoints.get(path);
+		return bps ? bps : [];
+	}
+
+	public inspect_object(
+		objectId: number,
+		inspected: (className: string, properties: any[]) => void
+	) {
+		this.serverController?.inspect_object(objectId, inspected);
+	}
+
+	public next() {
+		this.serverController?.next();
+	}
+
+	public remove_breakpoint(pathTo: string, line: number) {
+		let bps = this.breakpoints.get(pathTo);
+		if (bps) {
+			let index = bps.findIndex(bp => {
+				return bp.line === line;
+			});
+			if (index !== -1) {
+				let bp = bps[index];
+				bps.splice(index, 1);
+				this.breakpoints.set(pathTo, bps);
+				this.serverController?.remove_breakpoint(
+					bp.file.replace(new RegExp(`${this.project}/`), "res://"),
+					bp.line
+				);
+			}
+		}
+	}
+
+	public set_breakpoint(pathTo: string, line: number): GodotBreakpoint {
+		const BP = {
+			file: pathTo.replace(/\\/g, "/"),
+			line: line,
+			id: this.breakpointId++
+		};
+
+		let bps = this.breakpoints.get(BP.file);
+		if (!bps) {
+			bps = new Array<GodotBreakpoint>();
+			this.breakpoints.set(BP.file, bps);
+		}
+
+		bps.push(BP);
+
+		this.serverController?.set_breakpoint(
+			BP.file.replace(new RegExp(`${this.project}/`), "res://"),
+			line
+		);
+
+		return BP;
+	}
+
+	public start(
+		project: string,
+		address: string,
+		port: number,
+		launchGameInstance: boolean,
+		out: vscode.OutputChannel
+	) {
+		this.out = out;
+		this.out.show();
+
+		this.project = project.replace(/\\/g, "/");
+		if (this.project.match(/^[A-Z]:\//)) {
+			this.project = this.project[0].toLowerCase() + this.project.slice(1);
+		}
+
+		this.serverController = new ServerController(this, this.out);
+		let breakpointList: GodotBreakpoint[] = [];
+		Array.from(this.breakpoints.values()).forEach(fbp => {
+			breakpointList = breakpointList.concat(fbp);
+		});
+		this.serverController.start(
+			project,
+			port,
+			address,
+			launchGameInstance,
+			breakpointList
+		);
+	}
+
+	public step() {
+		this.serverController?.step();
+	}
+
+	public terminate() {
+		this.serverController?.stop();
+	}
+
+	public step_out() {
+		this.serverController?.step_out();
+	}
+}

--- a/src/debugger/godot_debug_runtime.ts
+++ b/src/debugger/godot_debug_runtime.ts
@@ -49,9 +49,9 @@ export class GodotDebugRuntime extends EventEmitter {
 			stackLevel: number,
 			stackFiles: string[],
 			scopes: {
-				locals: { name: string; value: any }[];
-				members: { name: string; value: any }[];
-				globals: { name: string; value: any }[];
+				locals: any[];
+				members: any[];
+				globals: any[];
 			}
 		) => void
 	) {

--- a/src/debugger/variable_scope.ts
+++ b/src/debugger/variable_scope.ts
@@ -1,0 +1,65 @@
+export class VariableScope {
+	private sub_variables = new Map<number, { name: string; value: any }[]>();
+	private variables = new Map<number, { name: string; value: any }>();
+
+	public readonly id: number;
+
+	constructor(id: number) {
+		this.id = id;
+	}
+
+	public get_id_for(name: string) {
+		let ids = Array.from(this.variables.keys());
+		return ids.find(v => {
+			let var_name = this.variables.get(v).name;
+			return var_name === name;
+		}) || -1;
+	}
+
+	public get_sub_variable_for(name: string, id: number) {
+		let sub_variables = this.sub_variables.get(id);
+		if (sub_variables) {
+			let index = sub_variables.findIndex(sv => {
+				return sv.name === name;
+			});
+			if (index !== -1) {
+				return sub_variables[index];
+			}
+		}
+
+		return undefined;
+	}
+
+	public get_sub_variables_for(id: number) {
+		return this.sub_variables.get(id);
+	}
+
+	public get_variable(id: number): { name: string; value: any } | undefined {
+		return this.variables.get(id);
+	}
+
+	public get_variable_ids() {
+		return Array.from(this.variables.keys());
+	}
+
+	public set_sub_variable_for(variable_id: number, name: string, value: any) {
+		let sub_variables = this.sub_variables.get(variable_id);
+		if (!sub_variables) {
+			sub_variables = [];
+			this.sub_variables.set(variable_id, sub_variables);
+		}
+
+		let index = sub_variables.findIndex(sv => {
+			return sv.name === name;
+		});
+
+		if (index === -1) {
+			sub_variables.push({ name: name, value: value });
+		}
+	}
+
+	public set_variable(name: string, value: any, id: number) {
+		let variable = { name: name, value: value };
+		this.variables.set(id, variable);
+	}
+}

--- a/src/debugger/variant_parser.ts
+++ b/src/debugger/variant_parser.ts
@@ -1,0 +1,711 @@
+enum GDScriptTypes {
+	NIL,
+
+	// atomic types
+	BOOL,
+	INT,
+	REAL,
+	STRING,
+
+	// math types
+
+	VECTOR2, // 5
+	RECT2,
+	VECTOR3,
+	TRANSFORM2D,
+	PLANE,
+	QUAT, // 10
+	AABB,
+	BASIS,
+	TRANSFORM,
+
+	// misc types
+	COLOR,
+	NODE_PATH, // 15
+	_RID,
+	OBJECT,
+	DICTIONARY,
+	ARRAY,
+
+	// arrays
+	POOL_BYTE_ARRAY, // 20
+	POOL_INT_ARRAY,
+	POOL_REAL_ARRAY,
+	POOL_STRING_ARRAY,
+	POOL_VECTOR2_ARRAY,
+	POOL_VECTOR3_ARRAY, // 25
+	POOL_COLOR_ARRAY,
+
+	VARIANT_MAX
+}
+
+interface BufferModel {
+	buffer: Buffer;
+	len: number;
+	offset: number;
+}
+
+export class VariantParser {
+	public decode_variant(model: BufferModel) {
+		let type = this.decode_UInt32(model);
+		switch (type & 0xff) {
+			case GDScriptTypes.BOOL:
+				return this.decode_UInt32(model) !== 0;
+			case GDScriptTypes.INT:
+				if (type & (1 << 16)) {
+					return this.decode_Int64(model);
+				} else {
+					return this.decode_Int32(model);
+				}
+			case GDScriptTypes.REAL:
+				if (type & (1 << 16)) {
+					return this.decode_Double(model);
+				} else {
+					return this.decode_Float(model);
+				}
+			case GDScriptTypes.STRING:
+				return this.decode_String(model);
+			case GDScriptTypes.VECTOR2:
+				return this.decode_Vector2(model);
+			case GDScriptTypes.RECT2:
+				return this.decode_Rect2(model);
+			case GDScriptTypes.VECTOR3:
+				return this.decode_Vector3(model);
+			case GDScriptTypes.TRANSFORM2D:
+				return this.decode_Transform2D(model);
+			case GDScriptTypes.PLANE:
+				return this.decode_Plane(model);
+			case GDScriptTypes.QUAT:
+				return this.decode_Quat(model);
+			case GDScriptTypes.AABB:
+				return this.decode_AABB(model);
+			case GDScriptTypes.BASIS:
+				return this.decode_Basis(model);
+			case GDScriptTypes.TRANSFORM:
+				return this.decode_Transform(model);
+			case GDScriptTypes.COLOR:
+				return this.decode_Color(model);
+			case GDScriptTypes.NODE_PATH:
+				return this.decode_NodePath(model);
+			case GDScriptTypes.OBJECT:
+				if (type & (1 << 16)) {
+					return this.decode_Object_id(model);
+				} else {
+					return this.decode_Object(model);
+				}
+			case GDScriptTypes.DICTIONARY:
+				return this.decode_Dictionary(model);
+			case GDScriptTypes.ARRAY:
+				return this.decode_Array(model);
+			case GDScriptTypes.POOL_BYTE_ARRAY:
+				return this.decode_PoolByteArray(model);
+			case GDScriptTypes.POOL_INT_ARRAY:
+				return this.decode_PoolIntArray(model);
+			case GDScriptTypes.POOL_REAL_ARRAY:
+				return this.decode_PoolFloatArray(model);
+			case GDScriptTypes.POOL_STRING_ARRAY:
+				return this.decode_PoolStringArray(model);
+			case GDScriptTypes.POOL_VECTOR2_ARRAY:
+				return this.decode_PoolVector2Array(model);
+			case GDScriptTypes.POOL_VECTOR3_ARRAY:
+				return this.decode_PoolVector3Array(model);
+			case GDScriptTypes.POOL_COLOR_ARRAY:
+				return this.decode_PoolColorArray(model);
+			default:
+				return undefined;
+		}
+	}
+
+	public encode_variant(
+		value: number | boolean | string | Map<any, any> | Array<any> | undefined,
+		model?: BufferModel
+	) {
+		if (!model) {
+			let size = this.size_variant(value);
+			let buffer = Buffer.alloc(size + 4);
+			model = {
+				buffer: buffer,
+				offset: 0,
+				len: 0
+			};
+			this.encode_UInt32(size, model);
+		}
+
+		switch (typeof value) {
+			case "number":
+				this.encode_UInt32(GDScriptTypes.INT, model);
+				this.encode_UInt32(value, model);
+				break;
+			case "boolean":
+				this.encode_UInt32(GDScriptTypes.BOOL, model);
+				this.encode_Bool(value, model);
+				break;
+			case "string":
+				this.encode_UInt32(GDScriptTypes.STRING, model);
+				this.encode_String(value, model);
+				break;
+			case "undefined":
+				break;
+			default:
+				if (Array.isArray(value)) {
+					this.encode_UInt32(GDScriptTypes.ARRAY, model);
+					this.encode_Array(value, model);
+				} else {
+					this.encode_UInt32(GDScriptTypes.DICTIONARY, model);
+					this.encode_Dictionary(value, model);
+				}
+		}
+
+		return model.buffer;
+	}
+
+	public get_buffer_dataset(buffer: Buffer, offset: number) {
+		let len = buffer.readUInt32LE(offset);
+		let model: BufferModel = {
+			buffer: buffer,
+			offset: offset + 4,
+			len: len
+		};
+
+		let output = [];
+		output.push(len + 4);
+		do {
+			let value = this.decode_variant(model);
+			output.push(value);
+		} while (model.len > 0);
+
+		return output;
+	}
+
+	private clean(value: number) {
+		return +Number.parseFloat(String(value)).toFixed(1);
+	}
+
+	private decode_AABB(model: BufferModel) {
+		let px = this.decode_Float(model);
+		let py = this.decode_Float(model);
+		let pz = this.decode_Float(model);
+		let sx = this.decode_Float(model);
+		let sy = this.decode_Float(model);
+		let sz = this.decode_Float(model);
+
+		return {
+			__type__: "AABB",
+			position: this.make_Vector3(px, py, pz),
+			size: this.make_Vector3(sx, sy, sz),
+			__render__: () =>
+				`AABB (${this.clean(px)}, ${this.clean(py)}, ${this.clean(
+					pz
+				)} - ${this.clean(sx)}, ${this.clean(sy)}, ${this.clean(sz)})`
+		};
+	}
+
+	private decode_Array(model: BufferModel) {
+		let output: Array<any> = [];
+
+		let count = this.decode_UInt32(model);
+
+		for (let i = 0; i < count; i++) {
+			let value = this.decode_variant(model);
+			output.push(value);
+		}
+
+		return output;
+	}
+
+	private decode_Basis(model: BufferModel) {
+		let x = this.decode_Vector3(model);
+		let y = this.decode_Vector3(model);
+		let z = this.decode_Vector3(model);
+
+		return this.make_Basis(
+			[x.x, x.y, z.z as number],
+			[y.x, y.y, y.z as number],
+			[z.x, z.y, z.z as number]
+		);
+	}
+
+	private decode_Color(model: BufferModel) {
+		let r = this.decode_Float(model);
+		let g = this.decode_Float(model);
+		let b = this.decode_Float(model);
+		let a = this.decode_Float(model);
+
+		return {
+			__type__: "Color",
+			r: r,
+			g: g,
+			b: b,
+			a: a,
+			__render__: () =>
+				`Color (${this.clean(r)}, ${this.clean(g)}, ${this.clean(
+					b
+				)}, ${this.clean(a)})`
+		};
+	}
+
+	private decode_Dictionary(model: BufferModel) {
+		let output = new Map<any, any>();
+
+		let count = this.decode_UInt32(model);
+		for (let i = 0; i < count; i++) {
+			let key = this.decode_variant(model);
+			let value = this.decode_variant(model);
+			output.set(key, value);
+		}
+
+		return output;
+	}
+
+	private decode_Double(model: BufferModel) {
+		let view = new DataView(model.buffer.buffer, model.offset, 8);
+		let d = view.getFloat64(0, true);
+
+		model.offset += 8;
+		model.len -= 8;
+
+		return d + 0.00000000001;
+	}
+
+	private decode_Float(model: BufferModel) {
+		let view = new DataView(model.buffer.buffer, model.offset, 4);
+		let f = view.getFloat32(0, true);
+
+		model.offset += 4;
+		model.len -= 4;
+
+		return f + 0.00000000001;
+	}
+
+	private decode_Int32(model: BufferModel) {
+		let u = model.buffer.readInt32LE(model.offset);
+		model.len -= 4;
+		model.offset += 4;
+
+		return u;
+	}
+
+	private decode_Int64(model: BufferModel) {
+		let view = new DataView(model.buffer.buffer, model.offset, 8);
+		let u = view.getBigInt64(0, true);
+		model.len -= 8;
+		model.offset += 8;
+
+		return Number(u);
+	}
+
+	private decode_NodePath(model: BufferModel) {
+		let name_count = this.decode_UInt32(model) & 0x7fffffff;
+		let subname_count = this.decode_UInt32(model);
+		let flags = this.decode_UInt32(model);
+		let is_absolute = (flags & 1) === 1;
+		if (flags & 2) {
+			//Obsolete format with property separate from subPath
+			subname_count++;
+		}
+
+		let total = name_count + subname_count;
+		let names: string[] = [];
+		let sub_names: string[] = [];
+		for (let i = 0; i < total; i++) {
+			let str = this.decode_String(model);
+			if (i < name_count) {
+				names.push(str);
+			} else {
+				sub_names.push(str);
+			}
+		}
+
+		return {
+			__type__: "NodePath",
+			path: names,
+			subpath: sub_names,
+			absolute: is_absolute,
+			__render__: () => `NodePath (${names.join(".")}:${sub_names.join(":")})`
+		};
+	}
+
+	private decode_Object(model: BufferModel) {
+		let class_name = this.decode_String(model);
+		let prop_count = this.decode_UInt32(model);
+		let props: { name: string; value: any }[] = [];
+		for (let i = 0; i < prop_count; i++) {
+			let name = this.decode_String(model);
+			let value = this.decode_variant(model);
+			props.push({ name: name, value: value });
+		}
+
+		return { __type__: class_name, properties: props };
+	}
+
+	private decode_Object_id(model: BufferModel) {
+		let id = this.decode_UInt64(model);
+		return {
+			__type__: "Object",
+			id: id,
+			__render__: () => `Object<${id}>`
+		};
+	}
+
+	private decode_Plane(model: BufferModel) {
+		let x = this.decode_Float(model);
+		let y = this.decode_Float(model);
+		let z = this.decode_Float(model);
+		let d = this.decode_Float(model);
+
+		return {
+			__type__: "Plane",
+			x: x,
+			y: y,
+			z: z,
+			d: d,
+			__render__: () =>
+				`Plane (${this.clean(x)}, ${this.clean(y)}, ${this.clean(
+					z
+				)}, ${this.clean(d)})`
+		};
+	}
+
+	private decode_PoolByteArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: number[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(model.buffer.readUInt8(model.offset));
+			model.offset++;
+			model.len--;
+		}
+
+		return output;
+	}
+
+	private decode_PoolColorArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: { r: number; g: number; b: number; a: number }[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Color(model));
+		}
+
+		return output;
+	}
+
+	private decode_PoolFloatArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: number[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Float(model));
+		}
+
+		return output;
+	}
+
+	private decode_PoolIntArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: number[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Int32(model));
+		}
+
+		return output;
+	}
+
+	private decode_PoolStringArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: string[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_String(model));
+		}
+
+		return output;
+	}
+
+	private decode_PoolVector2Array(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: { x: number; y: number }[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Vector2(model));
+		}
+
+		return output;
+	}
+
+	private decode_PoolVector3Array(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: { x: number; y: number; z: number | undefined }[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Vector3(model));
+		}
+
+		return output;
+	}
+
+	private decode_Quat(model: BufferModel) {
+		let x = this.decode_Float(model);
+		let y = this.decode_Float(model);
+		let z = this.decode_Float(model);
+		let w = this.decode_Float(model);
+
+		return {
+			__type__: "Quat",
+			x: x,
+			y: y,
+			z: z,
+			w: w,
+			__render__: () =>
+				`Quat (${this.clean(x)}, ${this.clean(y)}, ${this.clean(
+					z
+				)}, ${this.clean(w)})`
+		};
+	}
+
+	private decode_Rect2(model: BufferModel) {
+		let x = this.decode_Float(model);
+		let y = this.decode_Float(model);
+		let sizeX = this.decode_Float(model);
+		let sizeY = this.decode_Float(model);
+
+		return {
+			__type__: "Rect2",
+			position: this.make_Vector2(x, y),
+			size: this.make_Vector2(sizeX, sizeY),
+			__render__: () =>
+				`Rect2 (${this.clean(x)}, ${this.clean(y)} - ${this.clean(
+					sizeX
+				)}, ${this.clean(sizeY)})`
+		};
+	}
+
+	private decode_String(model: BufferModel) {
+		let len = this.decode_UInt32(model);
+		let pad = 0;
+		if (len % 4 !== 0) {
+			pad = 4 - (len % 4);
+		}
+
+		let str = model.buffer.toString("utf8", model.offset, model.offset + len);
+		len += pad;
+
+		model.offset += len;
+		model.len -= len;
+
+		return str;
+	}
+
+	private decode_Transform(model: BufferModel) {
+		let b = this.decode_Basis(model);
+		let o = this.decode_Vector3(model);
+
+		return {
+			__type__: "Transform",
+			basis: this.make_Basis(
+				[b.x.x, b.x.y, b.x.z as number],
+				[b.y.x, b.y.y, b.y.z as number],
+				[b.z.x, b.z.y, b.z.z as number]
+			),
+			origin: this.make_Vector3(o.x, o.y, o.z),
+			__render__: () =>
+				`Transform ((${this.clean(b.x.x)}, ${this.clean(b.x.y)}, ${this.clean(
+					b.x.z as number
+				)}), (${this.clean(b.y.x)}, ${this.clean(b.y.y)}, ${this.clean(
+					b.y.z as number
+				)}), (${this.clean(b.z.x)}, ${this.clean(b.z.y)}, ${this.clean(
+					b.z.z as number
+				)}) - (${this.clean(o.x)}, ${this.clean(o.y)}, ${this.clean(
+					o.z as number
+				)}))`
+		};
+	}
+
+	private decode_Transform2D(model: BufferModel) {
+		let origin = this.decode_Vector2(model);
+		let x = this.decode_Vector2(model);
+		let y = this.decode_Vector2(model);
+
+		return {
+			__type__: "Transform2D",
+			origin: this.make_Vector2(origin.x, origin.y),
+			x: this.make_Vector2(x.x, x.y),
+			y: this.make_Vector2(y.x, y.y),
+			__render__: () =>
+				`Transform2D ((${this.clean(origin.x)}, ${this.clean(
+					origin.y
+				)}) - (${this.clean(x.x)}, ${this.clean(x.y)}), (${this.clean(
+					y.x
+				)}, ${this.clean(y.x)}))`
+		};
+	}
+
+	private decode_UInt32(model: BufferModel) {
+		let u = model.buffer.readUInt32LE(model.offset);
+		model.len -= 4;
+		model.offset += 4;
+
+		return u;
+	}
+
+	private decode_UInt64(model: BufferModel) {
+		let view = new DataView(model.buffer.buffer, model.offset, 8);
+		let u = view.getBigUint64(0, true);
+		model.len -= 8;
+		model.offset += 8;
+
+		return Number(u);
+	}
+
+	private decode_Vector2(model: BufferModel) {
+		let x = this.decode_Float(model);
+		let y = this.decode_Float(model);
+
+		return this.make_Vector2(x, y);
+	}
+
+	private decode_Vector3(model: BufferModel) {
+		let x = this.decode_Float(model);
+		let y = this.decode_Float(model);
+		let z = this.decode_Float(model);
+
+		return this.make_Vector3(x, y, z);
+	}
+
+	private encode_Array(arr: any[], model: BufferModel) {
+		let size = arr.length;
+		this.encode_UInt32(size, model);
+		arr.forEach(e => {
+			this.encode_variant(e, model);
+		});
+	}
+
+	private encode_Bool(bool: boolean, model: BufferModel) {
+		this.encode_UInt32(bool ? 1 : 0, model);
+	}
+
+	private encode_Dictionary(dict: Map<any, any>, model: BufferModel) {
+		let size = dict.size;
+		this.encode_UInt32(size, model);
+		let keys = Array.from(dict.keys());
+		keys.forEach(key => {
+			let value = dict.get(key);
+			this.encode_variant(key, model);
+			this.encode_variant(value, model);
+		});
+	}
+
+	private encode_String(str: string, model: BufferModel) {
+		let str_len = str.length;
+		this.encode_UInt32(str_len, model);
+		model.buffer.write(str, model.offset, str_len, "utf8");
+		model.offset += str_len;
+		str_len += 4;
+		while (str_len % 4) {
+			str_len++;
+			model.buffer.writeUInt8(0, model.offset);
+			model.offset++;
+		}
+	}
+
+	private encode_UInt32(int: number, model: BufferModel) {
+		model.buffer.writeUInt32LE(int, model.offset);
+		model.offset += 4;
+	}
+
+	private make_Basis(x: number[], y: number[], z: number[]) {
+		return {
+			__type__: "Basis",
+			x: this.make_Vector3(x[0], x[1], x[2]),
+			y: this.make_Vector3(y[0], y[1], y[2]),
+			z: this.make_Vector3(z[0], z[1], z[2]),
+			__render__: () =>
+				`Basis ((${this.clean(x[0])}, ${this.clean(x[1])}, ${this.clean(
+					x[2]
+				)}), (${this.clean(y[0])}, ${this.clean(y[1])}, ${this.clean(
+					y[2]
+				)}), (${this.clean(z[0])}, ${this.clean(z[1])}, ${this.clean(z[2])}))`
+		};
+	}
+
+	private make_Vector2(x: number, y: number) {
+		return {
+			__type__: `Vector2`,
+			x: x,
+			y: y,
+			__render__: () => `Vector2 (${this.clean(x)}, ${this.clean(y)})`
+		};
+	}
+
+	private make_Vector3(x: number, y: number, z: number) {
+		return {
+			__type__: `Vector3`,
+			x: x,
+			y: y,
+			z: z,
+			__render__: () =>
+				`Vector3 (${this.clean(x)}, ${this.clean(y)}, ${this.clean(z)})`
+		};
+	}
+
+	private size_Bool(): number {
+		return this.size_UInt32();
+	}
+
+	private size_Dictionary(dict: Map<any, any>): number {
+		let size = this.size_UInt32();
+		let keys = Array.from(dict.keys());
+		keys.forEach(key => {
+			let value = dict.get(key);
+			size += this.size_variant(key);
+			size += this.size_variant(value);
+		});
+
+		return size;
+	}
+
+	private size_String(str: string): number {
+		let size = this.size_UInt32() + str.length;
+		while (size % 4) {
+			size++;
+		}
+		return size;
+	}
+
+	private size_UInt32(): number {
+		return 4;
+	}
+
+	private size_array(arr: any[]): number {
+		let size = this.size_UInt32();
+		arr.forEach(e => {
+			size += this.size_variant(e);
+		});
+
+		return size;
+	}
+
+	private size_variant(
+		value: number | boolean | string | Map<any, any> | any[] | undefined
+	): number {
+		let size = 4;
+
+		switch (typeof value) {
+			case "number":
+				size += this.size_UInt32();
+				break;
+			case "boolean":
+				size += this.size_Bool();
+				break;
+			case "string":
+				size += this.size_String(value);
+				break;
+			case "undefined":
+				break;
+			default:
+				if (Array.isArray(value)) {
+					size += this.size_array(value);
+					break;
+				} else {
+					size += this.size_Dictionary(value);
+					break;
+				}
+		}
+
+		return size;
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,13 @@
 import { ExtensionContext } from "vscode";
 import { GodotTools } from "./godot-tools";
-
+import debuggerContext = require("./debugger/debugger_context");
 
 let tools: GodotTools = null;
 
 export function activate(context: ExtensionContext) {
 	tools = new GodotTools(context);
 	tools.activate();
+	debuggerContext.register_debugger(context);
 }
 
 export function deactivate(): Thenable<void> {


### PR DESCRIPTION
I believe I've gotten the debugger fairly well integrated with the extension - though it kind of floats apart in the VSCode context, so there isn't much collaboration required with the existing systems. It doesn't conflict with it, though, so I guess that's the important part.

## Supports ##

- Step-in/next
- Step
- Continue
- Pause (though since Godot pausing doesn't report a breakpoint, the editor doesn't change, but hitting pause again will resume)
- Locals, members and globals scopes for variables while broken
- Scope drilling and objects-within-objects, including for Object types.
- Exceptions break differently and do not allow continue/step-in/step
- Stack trace and jumping between those frames
- Terminate
- A boolean in the launch config permits control over whether to launch a Godot instance, or wait for the remote debugger to launch (I.E. from the editor)

~~## Missing ##~~

~~Currently, things that extend Object (KinematicBody2D, Camera2D, etc) will show their class type, but their properties are not yet exposed to be printed. Given the Godot debugger is _very_ liberal about how much information it gives you when you call for an inspect_object command, this may be a bit excessive to show everything. Still, we do _receive_ the properties, just haven't done anything with them yet.~~

## To be done ##

Set up a branch in preparation for the upcoming [refactor](https://github.com/godotengine/godot/pull/36244) - I haven't looked at the code yet, but from reading the PR blurb it seems that the format of the commands will change somewhat.

---

I'll admit that my Typescript/javascript isn't the best, so any reviews are welcome. But it feels pretty thorough, and I can't think of anything else that's missing.