### PR TITLE
Issue 144

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test
 configurations/tmp.txt
 configurations/test.py
 .vscode-test
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
 
 #### Commands:
 
-__`godot-tools.run_godot(params: string = '')`__ <br/>
-This will launch godot, you can optionally give  it a string of arguments.
+__`godot-tools.run_godot(terminalName:string, params: string = '')`__ <br/>
+This will launch Godot via a terminal instance named `terminalName` for the current workspace.  If you specify an already existing terminal then that one will be closed and a new one will be created.  Any command line parameters specified in `params` will be passed to Godot.  
+
+__Note__ that this command auto-populates the `--path` command line parameter.
 ```typescript
 // launch godot to run the current workspace
-vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}"`);
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal');
 // run a scene
-vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}" path/to/scene.tscn`);
-
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal', 'path/to/scene.tscn');
 ```
 
 ## Issues and contributions

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The extension adds a few entries to the VS Code Command Palette under "Godot Too
 - Run the workspace as a Godot project
 - List Godot's native classes
 
+
 ## Settings
 
 ### Godot
@@ -52,6 +53,28 @@ You can use the following settings to configure Godot Tools:
 - `editor_path` - The absolute path to the Godot editor executable.
 - `gdscript_lsp_server_port` - The WebSocket server port of the GDScript language server.
 - `check_status` - Check the GDScript language server connection status.
+
+#### Use Godot Tools in your VSCode Extension
+If you have a VSCode plugin there are some commands that are only available via code that may be helpful.  This means your extension will require that this extension is installed.
+
+You can invoke other commands (Godot Tools, built-ins, or other plugins) with 
+```typescript
+vscode.commands.executeCommand('extension.command')
+// or with parameters
+vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
+```
+
+#### Godot Tools offers:
+
+`godot-tools.run_godot` <br/>
+This will launch godot, you can optionally give  it a string of arguments.
+```typescript
+// launch godot to run the current workspace
+vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}"`);
+// run a scene
+vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}" path/to/scene.tscn`);
+
+```
 
 ## Issues and contributions
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ vscode.commands.executeCommand('extension.command')
 vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
 ```
 
-#### Godot Tools offers:
+#### Commands:
 
-`godot-tools.run_godot` <br/>
+__`godot-tools.run_godot(params: string = '')`__ <br/>
 This will launch godot, you can optionally give  it a string of arguments.
 ```typescript
 // launch godot to run the current workspace

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "godot-tools",
 	"displayName": "godot-tools",
 	"icon": "icon.png",
-	"version": "1.0.1",
+	"version": "1.0.4",
 	"description": "Tools for game development with godot game engine",
 	"repository": "https://github.com/godotengine/godot-vscode-plugin",
 	"author": "The Godot Engine community",

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -33,11 +33,12 @@ export class GodotTools {
 
 		const command = 'godot-tool.run_godot';
     	const commandHandler = (params: string = '') => {
-			return new Promise((resolve, reject) => {
-	    	  this.run_editor(params).then(()=>resolve()).catch(err=>{
-					reject(err);
-				});
-			});
+			this.run_editor(params)
+			// return new Promise((resolve, reject) => {
+	    	//   this.run_editor(params).then(()=>resolve()).catch(err=>{
+			// 		reject(err);
+			// 	});
+			// });
     	};
     	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
 

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -31,6 +31,16 @@ export class GodotTools {
 		});
 		vscode.commands.registerCommand("godot-tool.check_status", this.check_client_status.bind(this));
 
+		const command = 'godot-tool.run_godot';
+    	const commandHandler = (params: string = '') => {
+			return new Promise((resolve, reject) => {
+	    	  this.run_editor(params).then(()=>resolve()).catch(err=>{
+					reject(err);
+				});
+			});
+    	};
+    	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
+
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
 		this.connection_status.show();

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -33,12 +33,7 @@ export class GodotTools {
 
 		const command = 'godot-tool.run_godot';
     	const commandHandler = (params: string = '') => {
-			this.run_editor(params)
-			// return new Promise((resolve, reject) => {
-	    	//   this.run_editor(params).then(()=>resolve()).catch(err=>{
-			// 		reject(err);
-			// 	});
-			// });
+			return this.open_workspace_with_editor(params)
     	};
     	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
 
@@ -47,7 +42,6 @@ export class GodotTools {
 		this.connection_status.show();
 		this.client.connect_to_server();
 	}
-
 
 
 	public deactivate() {


### PR DESCRIPTION
Adds `godot-tool.run_godot` command.  This is a non-palette command to be consumed by other extensions.

In testing the command I discovered that I had to add the `terminalName` parameter to prevent my launching of Godot to take over the Godot editor terminal.  I took the liberty of adding two terminal names, one for the editor and one for running the project.  I noticed that running the project would kill the editor.  I wasn't sure if this was "as designed" or not but it appeared to be a bug.  With these changes the running of the project won't kill the editor's terminal window.