### PR TITLE
Issue 144

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test
 configurations/tmp.txt
 configurations/test.py
 .vscode-test
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can use the following settings to configure Godot Tools:
 - `check_status` - Check the GDScript language server connection status.
 
 #### Use Godot Tools in your VSCode Extension
-If you have a VSCode plugin there are some commands that are only available via code that may be helpful.  This means your extension will require that this extension is installed.
+If you are creating a VSCode plugin there are some commands that Godot Tools provides via code.
 
 You can invoke other commands (Godot Tools, built-ins, or other plugins) with 
 ```typescript
@@ -63,18 +63,27 @@ vscode.commands.executeCommand('extension.command')
 // or with parameters
 vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
 ```
+All commands return a `Promise`.
+#### Godot Tools Commands:
 
-#### Commands:
-
-__`godot-tools.run_godot(terminalName:string, params: string = '')`__ <br/>
-This will launch Godot via a terminal instance named `terminalName` for the current workspace.  If you specify an already existing terminal then that one will be closed and a new one will be created.  Any command line parameters specified in `params` will be passed to Godot.  
+__`godot-tools.get_run_workspace_command()`__ <br/>
+This will return a `Promise` that will resolve into the current platform specific command you can use to launch Godot for the curretn workspace.  If the Godot executable defined in settings cannot be found then `undefined` will be returned.
 
 __Note__ that this command auto-populates the `--path` command line parameter.
 ```typescript
-// launch godot to run the current workspace
-vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal');
-// run a scene
-vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal', 'path/to/scene.tscn');
+// Using the command.
+vscode.commands.executeCommand('godot-tool.get_run_workspace_command').then(value => {
+    console.log(`Command to launch Godot = ${value}`);
+    // If you have a terminal instance you can run Godot like this:
+    if(value){
+      myTerminalInstance.sendText(value, true);
+    }    
+}, reason => {
+    // No errors are thrown as of now.
+    console.error(reason);
+  }
+);
+
 ```
 
 ## Issues and contributions

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
 
 #### Commands:
 
-__`godot-tools.run_godot(params: string = '')`__ <br/>
-This will launch godot, you can optionally give  it a string of arguments.
+__`godot-tools.run_godot(terminalName:string, params: string = '')`__ <br/>
+This will launch Godot via a terminal instance named `terminalName` for the current workspace.  If you specify an already existing terminal then that one will be closed and a new one will be created.  Any command line parameters specified in `params` will be passed to Godot.  
+
+__Note__ that this command auto-populates the `--path` command line parameter.
 ```typescript
 // launch godot to run the current workspace
-vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}"`);
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal');
 // run a scene
-vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}" path/to/scene.tscn`);
-
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal', 'path/to/scene.tscn');
 ```
 
 ## Issues and contributions

--- a/README.md
+++ b/README.md
@@ -85,7 +85,16 @@ vscode.commands.executeCommand('godot-tool.get_run_workspace_command').then(valu
 );
 
 ```
+__`godot-tools.run_godot(terminalName:string, params: string = '')`__ <br/>
+This will launch Godot via a terminal instance named `terminalName` for the current workspace.  If you specify an already existing terminal then that one will be closed and a new one will be created.  Any command line parameters specified in `params` will be passed to Godot.  
 
+__Note__ that this command auto-populates the `--path` command line parameter.
+```typescript
+// launch godot to run the current workspace
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal');
+// run a scene
+vscode.commands.executeCommand('godot-tool.run_godot', 'MyTerminal', 'path/to/scene.tscn');
+```
 ## Issues and contributions
 
 The [Godot Tools](https://github.com/godotengine/godot-vscode-plugin) extension

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The extension adds a few entries to the VS Code Command Palette under "Godot Too
 - Run the workspace as a Godot project
 - List Godot's native classes
 
+
 ## Settings
 
 ### Godot
@@ -52,6 +53,28 @@ You can use the following settings to configure Godot Tools:
 - `editor_path` - The absolute path to the Godot editor executable.
 - `gdscript_lsp_server_port` - The WebSocket server port of the GDScript language server.
 - `check_status` - Check the GDScript language server connection status.
+
+#### Use Godot Tools in your VSCode Extension
+If you have a VSCode plugin there are some commands that are only available via code that may be helpful.  This means your extension will require that this extension is installed.
+
+You can invoke other commands (Godot Tools, built-ins, or other plugins) with 
+```typescript
+vscode.commands.executeCommand('extension.command')
+// or with parameters
+vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
+```
+
+#### Godot Tools offers:
+
+`godot-tools.run_godot` <br/>
+This will launch godot, you can optionally give  it a string of arguments.
+```typescript
+// launch godot to run the current workspace
+vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}"`);
+// run a scene
+vscode.commands.executeCommand('godot-tool.run_godot', `--path "${this.workspace_dir}" path/to/scene.tscn`);
+
+```
 
 ## Issues and contributions
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ vscode.commands.executeCommand('extension.command')
 vscode.commands.executeCommand('extension.command', p1, p2, p3 ...)
 ```
 
-#### Godot Tools offers:
+#### Commands:
 
-`godot-tools.run_godot` <br/>
+__`godot-tools.run_godot(params: string = '')`__ <br/>
 This will launch godot, you can optionally give  it a string of arguments.
 ```typescript
 // launch godot to run the current workspace

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "godot-tools",
 	"displayName": "godot-tools",
 	"icon": "icon.png",
-	"version": "1.0.1",
+	"version": "1.0.4",
 	"description": "Tools for game development with godot game engine",
 	"repository": "https://github.com/godotengine/godot-vscode-plugin",
 	"author": "The Godot Engine community",

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -33,11 +33,12 @@ export class GodotTools {
 
 		const command = 'godot-tool.run_godot';
     	const commandHandler = (params: string = '') => {
-			return new Promise((resolve, reject) => {
-	    	  this.run_editor(params).then(()=>resolve()).catch(err=>{
-					reject(err);
-				});
-			});
+			this.run_editor(params)
+			// return new Promise((resolve, reject) => {
+	    	//   this.run_editor(params).then(()=>resolve()).catch(err=>{
+			// 		reject(err);
+			// 	});
+			// });
     	};
     	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
 

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -31,6 +31,16 @@ export class GodotTools {
 		});
 		vscode.commands.registerCommand("godot-tool.check_status", this.check_client_status.bind(this));
 
+		const command = 'godot-tool.run_godot';
+    	const commandHandler = (params: string = '') => {
+			return new Promise((resolve, reject) => {
+	    	  this.run_editor(params).then(()=>resolve()).catch(err=>{
+					reject(err);
+				});
+			});
+    	};
+    	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
+
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
 		this.connection_status.show();

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -33,12 +33,7 @@ export class GodotTools {
 
 		const command = 'godot-tool.run_godot';
     	const commandHandler = (params: string = '') => {
-			this.run_editor(params)
-			// return new Promise((resolve, reject) => {
-	    	//   this.run_editor(params).then(()=>resolve()).catch(err=>{
-			// 		reject(err);
-			// 	});
-			// });
+			return this.open_workspace_with_editor(params)
     	};
     	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
 
@@ -47,7 +42,6 @@ export class GodotTools {
 		this.connection_status.show();
 		this.client.connect_to_server();
 	}
-
 
 
 	public deactivate() {

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -34,7 +34,8 @@ export class GodotTools {
 		});
 		vscode.commands.registerCommand("godot-tool.check_status", this.check_client_status.bind(this));
 
-		this.addGetRunWorkspaceCommand();
+		this.addGetRunWorkspaceCommandCmd();
+		this.addRunGodotCmd();
 
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
@@ -47,7 +48,7 @@ export class GodotTools {
 		this.client.stop();
 	}
 
-	private addGetRunWorkspaceCommand(){
+	private addGetRunWorkspaceCommandCmd(){
 		const command = 'godot-tool.get_run_workspace_command';
     	const commandHandler = (terminalName:string,  params: string = '') => {
 			return new Promise((resolve, reject) => {
@@ -56,6 +57,15 @@ export class GodotTools {
     	};
     	this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
 	}
+
+	private addRunGodotCmd(){
+		const command = 'godot-tool.run_godot';
+		const commandHandler = (terminalName:string,  params: string = '') => {
+			return this.open_workspace_with_editor(terminalName, params)
+		};
+		this.context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
+	}
+	
 
 	private open_workspace_with_editor(terminalName:string,  params:string = "") {
 


### PR DESCRIPTION
Adds `godot-tool.get_run_workspace_command` non-pallette command that returns a platform dependent string to launch Godot for the currently opened workspace.

Adds `godot-tool.run_godot` command. This is a non-palette command to be consumed by other extensions.

In order to break out the logic for creating the command string I had to refactor the `run_editor` method to make the code accessible.  As I was doing this, I removed the dialog to find the Godot Editor and replaced it with an error message.  I did this for two reasons, one it made making the command easier.  The other was that the dialog was confusing to me when I started using the pluign.   I didn't see anything that told me what I was trying to find.  When you click the "open in editor" button and you get a file dialog you think it wants you to pick a file to open in the editor, not the Godot runtime.

I also noticed that running the project would kill the editor. I wasn't sure if this was "as designed" or not but it appeared to be a bug. With these changes the running of the project won't kill the editor's terminal window.  There is now two terminal names used, one for the editor and one for running the project.

I've verified these changes on Mac and PC.