### PR TITLE
Fix default debug config not using full filepath

### DIFF
--- a/src/debugger/debugger_context.ts
+++ b/src/debugger/debugger_context.ts
@@ -176,7 +176,7 @@ class GodotConfigurationProvider implements DebugConfigurationProvider {
 	): ProviderResult<DebugConfiguration> {
 		if (!config.type && !config.request && !config.name) {
 			const editor = window.activeTextEditor;
-			if (editor && fs.existsSync(`${folder}/project.godot`)) {
+			if (editor && fs.existsSync(`${folder.uri.fsPath}/project.godot`)) {
 				config.type = "godot";
 				config.name = "Debug Godot";
 				config.request = "launch";


### PR DESCRIPTION
When a launch.json is not found, the code that creates a temporary default configuration couldn't find the project.godot file as it didn't use the file system path, just the folder name. As a result, it couldn't find project.godot even when one was there.

Fixes #167 