### PR TITLE
Add ability for user to set scene file on right click in explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,7 +287,6 @@
 			"explorer/context": [
 				{
 					"command": "godot-tool.set_scene_file",
-					"when": "resourceLangId == properties && resourceExtname == .tscn",
 					"group": "2_workspace"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
 					"light": "resources/light/icon_edit.svg",
 					"dark": "resources/dark/icon_edit.svg"
 				}
+			},
+			{
+				"command": "godot-tool.set_scene_file",
+				"title": "Set as Scene File"
 			}
 		],
 		"configuration": {
@@ -81,8 +85,13 @@
 			"title": "Godot Tools configuration",
 			"properties": {
 				"godot_tools.gdscript_lsp_server_protocol": {
-					"type": ["string"],
-					"enum": ["ws", "tcp"],
+					"type": [
+						"string"
+					],
+					"enum": [
+						"ws",
+						"tcp"
+					],
 					"default": "tcp",
 					"enumDescriptions": [
 						"Using WebSocket protocol to connect to Godot 3.2 and Godot 3.2.1",
@@ -100,7 +109,12 @@
 					"default": "",
 					"description": "The absolute path to the Godot editor executable"
 				},
-				"godot-tool.check_status": {
+				"godot_tools.scene_file_config": {
+					"type": "string",
+					"default": "",
+					"description": "The scene file to run"
+				},
+				"godot-tools.check_status": {
 					"type": "string",
 					"default": "",
 					"description": "Check the gdscript language server connection status"
@@ -268,6 +282,13 @@
 					"command": "godot-tool.debugger.edit_value",
 					"when": "view == inspect-node && viewItem == editable_value",
 					"group": "inline"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "godot-tool.set_scene_file",
+					"when": "resourceLangId == properties && resourceExtname == .tscn",
+					"group": "2_workspace"
 				}
 			]
 		}

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -229,16 +229,13 @@ export class GodotDebugSession extends LoggingDebugSession {
 		await this.configuration_done.wait(2000);
 		this.exception = false;
 		this.debug_data.project_path = args.project;
-		if (get_configuration("scene_file_config", "") != "") {
-			args.scene_file = get_configuration("scene_file_config", "")
-		}
 		Mediator.notify("start", [
 			args.project,
 			args.address,
 			args.port,
 			args.launch_game_instance,
 			args.launch_scene,
-			args.scene_file,
+			get_configuration("scene_file_config", "") || args.scene_file,
 		]);
 		
 		this.sendResponse(response);

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -13,6 +13,7 @@ import { ServerController } from "./server_controller";
 const { Subject } = require("await-notify");
 import fs = require("fs");
 import { SceneTreeProvider } from "./scene_tree/scene_tree_provider";
+import { get_configuration } from "../utils";
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	address: string;
@@ -228,6 +229,9 @@ export class GodotDebugSession extends LoggingDebugSession {
 		await this.configuration_done.wait(2000);
 		this.exception = false;
 		this.debug_data.project_path = args.project;
+		if (get_configuration("scene_file_config", "") != "") {
+			args.scene_file = get_configuration("scene_file_config", "")
+		}
 		Mediator.notify("start", [
 			args.project,
 			args.address,
@@ -236,6 +240,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			args.launch_scene,
 			args.scene_file,
 		]);
+		
 		this.sendResponse(response);
 	}
 

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -30,6 +30,7 @@ export class GodotTools {
 			this.open_workspace_with_editor().catch(err=>vscode.window.showErrorMessage(err));
 		});
 		vscode.commands.registerCommand("godot-tool.check_status", this.check_client_status.bind(this));
+		vscode.commands.registerCommand("godot-tool.set_scene_file", this.set_scene_file.bind(this));
 
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
@@ -61,6 +62,20 @@ export class GodotTools {
 			}
 		});
 	}
+
+	private set_scene_file(uri: vscode.Uri) {
+		let right_clicked_scene_path = uri.fsPath
+		let scene_config = get_configuration("scene_file_config");
+		if (scene_config == right_clicked_scene_path) {
+			scene_config = ""
+		}
+		else {
+			scene_config = right_clicked_scene_path
+		}
+		
+		set_configuration("scene_file_config", scene_config);
+	}
+
 
 	private run_editor(params = "") {
 


### PR DESCRIPTION
Right clicking on a .tscn file will allow you to press "Set as Scene File" and set that file as the debugger's scene_file ([line 187 of package.json](https://github.com/godotengine/godot-vscode-plugin/blob/master/package.json#L187-L191))

This is done by setting an additional workspace configuration "godot_tools.scene_file_config". 

-If godot_tools.scene_file_config is set through right click, it overrides "scene_file" found in     launch.json. The value of "scene_file", however, remains untouched.

-Right Clicking the same .tscn file as scene_file_config and pressing "Set as Scene File" will unset scene_file_config