### PR TITLE
Fix debug server not closing properly, fix set breakpoints before project path is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ experience as comfortable as possible:
 - Ctrl + click on a variable or method call to jump to its definition
 - Full documentation of the Godot Engine's API supported
 - Run a Godot project from VS Code
-- Debug your Godot project from VS Code with breakpoints, step-in/out/over, variable watch, call stack, and active scene tree
+- Debug your GDScript-based Godot project from VS Code with breakpoints, step-in/out/over, variable watch, call stack, and active scene tree
 
 ![Showing the documentation on hover feature](img/godot-tools.png)
 
@@ -50,13 +50,15 @@ for Godot by following these steps:
 
 You can use the following settings to configure Godot Tools:
 
-- `editor_path` - The absolute path to the Godot editor executable.
+- `editor_path` - The absolute path to the Godot editor executable. _Under Mac OS, this is the executable inside of Godot.app._
 - `gdscript_lsp_server_port` - The WebSocket server port of the GDScript language server.
 - `check_status` - Check the GDScript language server connection status.
 
-#### Debugger
+#### GDScript Debugger
 
-To configure the debugger:
+The debugger is for GDScript projects. To debug C# projects, use [C# Tools for Godot](https://github.com/godotengine/godot-csharp-vscode).
+
+To configure the GDScript debugger:
 
 1. Open the command palette:
 2. `>Debug: Open launch.json`

--- a/package.json
+++ b/package.json
@@ -81,8 +81,13 @@
 			"title": "Godot Tools configuration",
 			"properties": {
 				"godot_tools.gdscript_lsp_server_protocol": {
-					"type": ["string"],
-					"enum": ["ws", "tcp"],
+					"type": [
+						"string"
+					],
+					"enum": [
+						"ws",
+						"tcp"
+					],
 					"default": "tcp",
 					"enumDescriptions": [
 						"Using WebSocket protocol to connect to Godot 3.2 and Godot 3.2.1",
@@ -148,7 +153,7 @@
 		"debuggers": [
 			{
 				"type": "godot",
-				"label": "Godot Debug",
+				"label": "GDScript Godot Debug",
 				"program": "./out/debugger/debug_adapter.js",
 				"runtime": "node",
 				"configurationAttributes": {
@@ -194,7 +199,7 @@
 				},
 				"initialConfigurations": [
 					{
-						"name": "Godot",
+						"name": "GDScript Godot",
 						"type": "godot",
 						"request": "launch",
 						"project": "${workspaceFolder}",
@@ -206,7 +211,7 @@
 				],
 				"configurationSnippets": [
 					{
-						"label": "Godot Debug: Launch",
+						"label": "GDScript Godot Debug: Launch",
 						"description": "A new configuration for debugging a Godot project.",
 						"body": {
 							"type": "godot",

--- a/src/debugger/mediator.ts
+++ b/src/debugger/mediator.ts
@@ -152,13 +152,13 @@ export class Mediator {
 
 			case "stop":
 				this.controller?.stop();
-				this.session?.sendEvent(new TerminatedEvent(false));
+				this.session?.sendEvent(new TerminatedEvent());
 				break;
 
 			case "error":
 				this.controller?.set_exception(parameters[0]);
 				this.controller?.stop();
-				this.session?.sendEvent(new TerminatedEvent(false));
+				this.session?.sendEvent(new TerminatedEvent());
 				break;
 		}
 	}

--- a/src/debugger/scene_tree/inspector_provider.ts
+++ b/src/debugger/scene_tree/inspector_provider.ts
@@ -23,7 +23,7 @@ export class InspectorProvider implements TreeDataProvider<RemoteProperty> {
 	public clean_up() {
 		if (this.tree) {
 			this.tree = undefined;
-			this._on_did_change_tree_data.fire(this.tree);
+			this._on_did_change_tree_data.fire(undefined);
 		}
 	}
 
@@ -37,7 +37,7 @@ export class InspectorProvider implements TreeDataProvider<RemoteProperty> {
 		this.tree.label = element_name;
 		this.tree.collapsibleState = TreeItemCollapsibleState.Expanded;
 		this.tree.description = class_name;
-		this._on_did_change_tree_data.fire(this.tree);
+		this._on_did_change_tree_data.fire(undefined);
 	}
 
 	public getChildren(
@@ -133,7 +133,8 @@ export class InspectorProvider implements TreeDataProvider<RemoteProperty> {
 
 		if (value) {
 			let sub_variables =
-				typeof value["sub_values"] === "function" && value instanceof ObjectId === false
+				typeof value["sub_values"] === "function" &&
+				value instanceof ObjectId === false
 					? value.sub_values()
 					: Array.isArray(value)
 					? value.map((va, i) => {

--- a/src/debugger/scene_tree/scene_tree_provider.ts
+++ b/src/debugger/scene_tree/scene_tree_provider.ts
@@ -22,7 +22,7 @@ export class SceneTreeProvider implements TreeDataProvider<SceneNode> {
 
 	public fill_tree(tree: SceneNode) {
 		this.tree = tree;
-		this._on_did_change_tree_data.fire(this.tree);
+		this._on_did_change_tree_data.fire(undefined);
 	}
 
 	public getChildren(element?: SceneNode): ProviderResult<SceneNode[]> {


### PR DESCRIPTION
This would prevent the socket from cleaning up, so it wouldn't send messages to the debugger. Fixes #175 

Also removes an unnecessary await that, for some people, caused breakpoints to be set before debugger was configured. Fixes #168 