### PR TITLE
Fix breakpoints out of order and confusing VSCode

### DIFF
--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -302,6 +302,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			});
 
 			bps = this.debug_data.get_breakpoints(path);
+			bps.sort((a, b) => (a.line < b.line ? -1 : 1));
 
 			response.body = {
 				breakpoints: bps.map((bp) => {

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -302,6 +302,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			});
 
 			bps = this.debug_data.get_breakpoints(path);
+			// Sort to ensure breakpoints aren't out-of-order, which would confuse VS Code.
 			bps.sort((a, b) => (a.line < b.line ? -1 : 1));
 
 			response.body = {


### PR DESCRIPTION
It appears that the way VSCode determines what breakpoint is toggled is via a sorted array of IDs instead of line numbers, so the arguments that the setBreakpointRerquests would send were not guaranteed to be in order.

Fixes #215