### PR TITLE
Check for updates to GitHub Actions every weekday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Now that dependabot is native to GitHub and this project uses actions, it would be nice to always keep them up to date. This PR will allow dependabot to check for updates to any actions uses and submit PRs with version bumps automatically.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot