### PR TITLE
Remove the configuration item 'godot-tools.check_config' as it has no effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,11 +113,6 @@
 					"type": "string",
 					"default": "",
 					"description": "The scene file to run"
-				},
-				"godot-tools.check_status": {
-					"type": "string",
-					"default": "",
-					"description": "Check the gdscript language server connection status"
 				}
 			}
 		},


### PR DESCRIPTION
Fixes #240.

As said in the issue comment :

> I don't know what is its initial intended behaviour. I think it's just to hide the indicator at the bottom right of the editor, since disabling the status check is not possible.
> 
> If you know the original intent of that option please let me know.