### PR TITLE
Change `$` node path shorthand regex to match only valid paths

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -204,7 +204,7 @@
       "name": "support.function.builtin.gdscript"
     },
     "builtin_get_node_shorthand": {
-      "match": "\\$[A-Za-z0-9\\_\\/]+",
+      "match": "\\$((\\\"(\\.\\.\\/)+|\\\"\\/|\\\"[0-9]+|\\\")([0-9A-Za-z]+\\/)*[A-Za-z0-9]+\\\"|[A-Za-z]+(\\/[A-Za-z]+)*)",
       "name": "support.function.builtin.shorthand.gdscript"
     },
     "builtin_classes": {

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -204,7 +204,7 @@
       "name": "support.function.builtin.gdscript"
     },
     "builtin_get_node_shorthand": {
-      "match": "\\$((\\\"(\\.\\.\\/)+|\\\"\\/|\\\"[0-9]+|\\\")([0-9A-Za-z]+\\/)*[A-Za-z0-9]+\\\"|[A-Za-z]+(\\/[A-Za-z]+)*)",
+      "match": "\\$((\\\"(\\.\\.\\/)+|\\\"\\/|\\\"[0-9]+|\\\")([0-9A-Za-z\\_]+\\/)*[A-Za-z0-9\\_]+\\\"|[A-Za-z\\_]+(\\/[A-Za-z\\_]+)*)",
       "name": "support.function.builtin.shorthand.gdscript"
     },
     "builtin_classes": {

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -8,4 +8,4 @@ When creating regexes it is sometimes useful to test against a data set.
 
 [Regex101](https://regex101.com/) allows for pretty good match testing, unfortunately it does not support the regex (ruby) version that TextMate uses.
 
-[ExtendsClass's](https://extendsclass.com/regex-tester.html#ruby) regex engine does support the ruby the variant but the match testing experience is not as good. However it does automatically generate an FSM for your regex, which is very useful in debugging.
+[ExtendsClass's](https://extendsclass.com/regex-tester.html#ruby) regex engine does support the Ruby variant, but the match testing experience is not as good. However, it automatically generates an FSM for your regex, which is very useful when debugging.

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -6,6 +6,6 @@ You can find the regex syntax that VSCode uses [here](https://macromates.com/man
 
 When creating regexes it is sometimes useful to test against a data set.
 
-[Regex101]() allows for pretty good match testing, unfortunately it does not support the regex (ruby) version that TextMate uses.
+[Regex101](https://regex101.com/) allows for pretty good match testing, unfortunately it does not support the regex (ruby) version that TextMate uses.
 
-[ExtendsClass's]() regex engine does support the ruby the variant but the match testing experience is not as good. However it does automatically generate an FSM for your regex, which is very useful in debugging.
+[ExtendsClass's](https://extendsclass.com/regex-tester.html#ruby) regex engine does support the ruby the variant but the match testing experience is not as good. However it does automatically generate an FSM for your regex, which is very useful in debugging.

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -1,0 +1,11 @@
+# Helpful resources
+
+You can find the regex syntax that VSCode uses [here](https://macromates.com/manual/en/regular_expressions).
+
+## Creating and debugging regex
+
+When creating regexes it is sometimes useful to test against a data set.
+
+[Regex101]() allows for pretty good match testing, unfortunately it does not support the regex (ruby) version that TextMate uses.
+
+[ExtendsClass's]() regex engine does support the ruby the variant but the match testing experience is not as good. However it does automatically generate an FSM for your regex, which is very useful in debugging.

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -6,6 +6,6 @@ You can find the regex syntax that VSCode uses [here](https://macromates.com/man
 
 When creating regexes it is sometimes useful to test against a data set.
 
-[Regex101](https://regex101.com/) allows for pretty good match testing, unfortunately it does not support the regex (ruby) version that TextMate uses.
+[Regex101](https://regex101.com/) allows for pretty good match testing. Unfortunately, it does not support the regex (Ruby) version that TextMate uses.
 
 [ExtendsClass's](https://extendsclass.com/regex-tester.html#ruby) regex engine does support the Ruby variant, but the match testing experience is not as good. However, it automatically generates an FSM for your regex, which is very useful when debugging.


### PR DESCRIPTION
- Changed regex to allow only valid paths as discussed in #275 
- Added a `README.md` with useful information for debugging and creating regexes for the GDScript syntax.