### PR TITLE
Fix conditional breakpoints being parsed as regular breakpoints

### DIFF
--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -298,7 +298,10 @@ export class GodotDebugSession extends LoggingDebugSession {
 			});
 			client_lines.forEach((l) => {
 				if (bp_lines.indexOf(l) === -1) {
-					this.debug_data.set_breakpoint(path, l);
+					let bp = args.breakpoints.find((bp_at_line) => (bp_at_line.line == l));
+					if(!bp.condition) {
+						this.debug_data.set_breakpoint(path, l);
+					}
 				}
 			});
 

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -299,7 +299,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			client_lines.forEach((l) => {
 				if (bp_lines.indexOf(l) === -1) {
 					let bp = args.breakpoints.find((bp_at_line) => (bp_at_line.line == l));
-					if(!bp.condition) {
+					if (!bp.condition) {
 						this.debug_data.set_breakpoint(path, l);
 					}
 				}


### PR DESCRIPTION
Despite `supportsConditionalBreakpoints` being set to `false`, seems the debug adapter still expects the debugger to explicitly filter out conditional breakpoints, or continue treating them as regular breakpoints (which makes the presence of `supportsConditionalBReakpoint` kind of pointless? I dunno.)

Until Godot supports conditional breakpoints, I'm opting to just remove them entirely as there's no feasible way of hooking into the debugger so there's no confusion. Now they'll be ignored.

Fixes #267