### PR TITLE
Fix "Continue" for multiple breakpoints in the same script

### DIFF
--- a/src/debugger/debug_runtime.ts
+++ b/src/debugger/debug_runtime.ts
@@ -82,8 +82,9 @@ export class GodotDebugData {
 
 		bps.push(bp);
 
-		let out_file = `res://${path.relative(this.project_path, bp.file)}`;
-
-		Mediator.notify("set_breakpoint", [out_file.replace(/\\/g, "/"), line]);
+		if (this.project_path) {
+			let out_file = `res://${path.relative(this.project_path, bp.file)}`;
+			Mediator.notify("set_breakpoint", [out_file.replace(/\\/g, "/"), line]);
+		}
 	}
 }


### PR DESCRIPTION
Fixes issue #296

When starting a new debug session a `setBreakPointsRequest()` is triggered for each file that contains breakpoints.
However at that time `this.project_path` is still undefined. It will only be initialized during the `launchRequest()`.
Trying to pass `undefined` into `path.relative()` will cause a type error which means the `setBreakPointsRequest()` will fail and exit after the first breakpoint of each file.

With this fix we skip the respective lines during initialization.
At that time the `project_path` is still unknown so we can't construct the relative path.
Also the Mediator isn't connected yet, so these lines wouldn't do anything anyway.