### PR TITLE
Use the LSP defined SymbolKind enum and fix marked

### DIFF
--- a/src/lsp/NativeDocumentManager.ts
+++ b/src/lsp/NativeDocumentManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as ls from "vscode-languageclient";
 import { EventEmitter } from "events";
 import { MessageIO } from "./MessageIO";
 import { NotificationMessage } from "vscode-jsonrpc";
@@ -190,8 +191,8 @@ export default class NativeDocumentManager extends EventEmitter {
 			with_class = false
 		): { index?: string; body: string } {
 			switch (s.kind) {
-				case vscode.SymbolKind.Property:
-				case vscode.SymbolKind.Variable:
+				case ls.SymbolKind.Property:
+				case ls.SymbolKind.Variable:
 					{
 						// var Control.anchor_left: float
 						const parts = /\.([A-z_0-9]+)\:\s(.*)$/.exec(s.detail);
@@ -215,7 +216,7 @@ export default class NativeDocumentManager extends EventEmitter {
 						};
 					}
 					break;
-				case vscode.SymbolKind.Constant:
+				case ls.SymbolKind.Constant:
 					{
 						// const Control.FOCUS_ALL: FocusMode = 2
 						// const Control.NOTIFICATION_RESIZED = 40
@@ -243,7 +244,7 @@ export default class NativeDocumentManager extends EventEmitter {
 						};
 					}
 					break;
-				case vscode.SymbolKind.Event:
+				case ls.SymbolKind.Event:
 					{
 						const parts = /\.([A-z0-9]+)\((.*)?\)/.exec(s.detail);
 						if (!parts) {
@@ -269,8 +270,8 @@ export default class NativeDocumentManager extends EventEmitter {
 						};
 					}
 					break;
-				case vscode.SymbolKind.Method:
-				case vscode.SymbolKind.Function:
+				case ls.SymbolKind.Method:
+				case ls.SymbolKind.Function:
 					{
 						const signature = make_function_signature(s, with_class);
 						const title = element("h4", signature);
@@ -290,7 +291,7 @@ export default class NativeDocumentManager extends EventEmitter {
 			}
 		}
 
-		if (symbol.kind == vscode.SymbolKind.Class) {
+		if (symbol.kind == ls.SymbolKind.Class) {
 			let doc = element("h2", `Native class ${symbol.name}`);
 			const parts = /extends\s+([A-z0-9]+)/.exec(symbol.detail);
 			let inherits = parts && parts.length > 1 ? parts[1] : "";
@@ -326,19 +327,19 @@ export default class NativeDocumentManager extends EventEmitter {
 			for (let s of symbol.children as GodotNativeSymbol[]) {
 				const elements = make_symbol_elements(s);
 				switch (s.kind) {
-					case vscode.SymbolKind.Property:
-					case vscode.SymbolKind.Variable:
+					case ls.SymbolKind.Property:
+					case ls.SymbolKind.Variable:
 						properties_index += element("li", elements.index);
 						propertyies += element("li", elements.body, { id: s.name });
 						break;
-					case vscode.SymbolKind.Constant:
+					case ls.SymbolKind.Constant:
 						constants += element("li", elements.body, { id: s.name });
 						break;
-					case vscode.SymbolKind.Event:
+					case ls.SymbolKind.Event:
 						signals += element("li", elements.body, { id: s.name });
 						break;
-					case vscode.SymbolKind.Method:
-					case vscode.SymbolKind.Function:
+					case ls.SymbolKind.Method:
+					case ls.SymbolKind.Function:
 						methods_index += element("li", elements.index);
 						methods += element("li", elements.body, { id: s.name });
 						break;
@@ -373,11 +374,8 @@ export default class NativeDocumentManager extends EventEmitter {
 			let doc = "";
 			const elements = make_symbol_elements(symbol, true);
 			if (elements.index) {
-				if (
-					[vscode.SymbolKind.Function, vscode.SymbolKind.Method].indexOf(
-						symbol.kind
-					) == -1
-				) {
+				const symbols: ls.SymbolKind[] = [ls.SymbolKind.Function, ls.SymbolKind.Method];
+				if (!symbols.includes(symbol.kind)) {
 					doc += element("h2", elements.index);
 				}
 			}
@@ -419,7 +417,7 @@ function make_link(classname: string, symbol: string) {
 }
 
 function make_codeblock(code: string) {
-	const md = marked("```gdscript\n" + code + "\n```");
+	const md = marked.parse("```gdscript\n" + code + "\n```");
 	return `<div class="codeblock">${md}</div>`;
 }
 

--- a/src/lsp/gdscript.capabilities.ts
+++ b/src/lsp/gdscript.capabilities.ts
@@ -1,4 +1,4 @@
-import { DocumentSymbol } from "vscode";
+import { DocumentSymbol } from "vscode-languageclient";
 
 export const enum Methods {
 	GDSCRIPT_CAPABILITIES = 'gdscript/capabilities',


### PR DESCRIPTION
Since Godot uses the `SymbolKind` enum defined by the [LSP protocol](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol) instead of the one defined by [VSCode](https://github.com/microsoft/vscode/blob/459ffea03c117042c17c6a3c02f066c4af5db555/src/vs/editor/common/languages.ts#L1175-L1202).
This enum was changed in Godot in https://github.com/godotengine/godot/pull/50913 and was backported to 3.x in https://github.com/godotengine/godot/pull/50914.

Also fixes `marked` being called incorrectly to parse codeblocks.

Fixes #321