### PR TITLE
Fix restart of debugging sessions

### DIFF
--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -89,6 +89,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 		args: DebugProtocol.ConfigurationDoneArguments
 	) {
 		this.configuration_done.notify();
+		this.sendResponse(response);
 	}
 
 	public set_scopes(
@@ -236,7 +237,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			args.launch_scene,
 			get_configuration("scene_file_config", "") || args.scene_file,
 		]);
-		
+
 		this.sendResponse(response);
 	}
 


### PR DESCRIPTION
We have to send a response to the `configurationDoneRequest` or else vscode will run into a timeout and disconnect the debug adapter. For some reason this timeout does not apply when launching the session initially. That's why stopping and then starting a new session worked before.

Fixes #282