### PR TITLE
Improve syntax highlighting

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -88,7 +88,7 @@
     },
     "logic_op": {
       "match": "\\b(and|or|not)\\b",
-      "name": "keyword.operator.logical.gdscript"
+      "name": "keyword.operator.wordlike.gdscript"
     },
     "compare_op": {
       "match": "<=|>=|==|<|>|!=",
@@ -104,8 +104,16 @@
     },
 
     "keywords": {
-      "match": "\\b(?i:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|in|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|in)\\b",
-      "name": "keyword.language.gdscript"
+      "patterns": [
+        {
+          "match": "\\b(?i:func|class|class_name|extends|is|in|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|in)\\b",
+          "name": "keyword.language.gdscript"
+        },
+        {
+          "match": "\\b(?i:if|elif|else|for|while|break|continue|pass|return|match)\\b",
+          "name": "keyword.control"
+        }
+      ]
     },
     "letter": {
         "match": "\\b(?i:true|false|null)\\b",


### PR DESCRIPTION
This pull request makes the syntax highlighting of GDScript more closely match the built-in Godot editor's, as well as VSCode's Python syntax highlighting.

Before:
![keywords_before](https://user-images.githubusercontent.com/31112680/158921462-24afff1d-a711-4d1c-a0de-2c25ebc97cf4.jpg)
After:
![keywords_after](https://user-images.githubusercontent.com/31112680/158921477-ead18ca2-8934-4d76-aee9-65fa1f835e88.jpg)

Godot editor:
![keywords_godoteditor](https://user-images.githubusercontent.com/31112680/158921537-41f90a68-02dd-405f-9cdd-585e12fe581f.jpg)
VSCode Python:
![keywords_python](https://user-images.githubusercontent.com/31112680/158921554-497dad7b-087e-421b-96bb-640280252a86.jpg)

