### PR TITLE
Add macOS editor location to README since it's not obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ for Godot by following these steps:
 2. Select **Text Editor > External**
 3. Make sure the **Use External Editor** box is checked
 4. Fill **Exec Path** with the path to your VS Code executable
+    * Mac OS: `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`
 5. Fill **Exec Flags** with `{project} --goto {file}:{line}:{col}`
 
 ### VS Code

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for Godot by following these steps:
 2. Select **Text Editor > External**
 3. Make sure the **Use External Editor** box is checked
 4. Fill **Exec Path** with the path to your VS Code executable
-    * Mac OS: `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`
+    * On macOS, this executable is typically located at: `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`
 5. Fill **Exec Flags** with `{project} --goto {file}:{line}:{col}`
 
 ### VS Code


### PR DESCRIPTION
Dug around for this for a while until finding a random steam thread: https://steamcommunity.com/app/404790/discussions/0/2579854400740817169/

Adding to the README for future travelers