### PR TITLE
Fix some `$` node path shorthand regex bugs in syntax highlighting

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -212,7 +212,7 @@
       "name": "support.function.builtin.gdscript"
     },
     "builtin_get_node_shorthand": {
-      "match": "\\$((\\\"(\\.\\.\\/)+|\\\"\\/|\\\"[0-9]+|\\\")([0-9A-Za-z\\_]+\\/)*[A-Za-z0-9\\_]+\\\"|[A-Za-z\\_]+(\\/[A-Za-z\\_]+)*)",
+      "match": "\\$(((?<quote>\"|')((\\.\\.\\/)+|\\/)?)[0-9A-Za-z_ ]+(\\/[0-9A-Za-z_ ]+)*\\k<quote>|[0-9A-Za-z_]+(\\/[0-9A-Za-z_]+)*)",
       "name": "support.function.builtin.shorthand.gdscript"
     },
     "builtin_classes": {


### PR DESCRIPTION
The regex now supports:
  - Unquoted node paths with numbers eg. `$Node2D/Area2D`
  - Single-quoted node paths eg. `$'Node/Sprite'`
  - Quoted node paths with spaces eg. `$"Node/Main Menu"`

Old regex syntax diagram:
![chrome_OsBUvsPq1a](https://user-images.githubusercontent.com/1632314/161725040-790d9d61-6f31-41b6-8673-82772ff2b248.png)

New regex syntax diagram:
![chrome_Exuu49GF8Z](https://user-images.githubusercontent.com/1632314/161725052-c0a496c7-7453-4ceb-ad2c-472a76a7bd61.png)