### PR TITLE
Fix keywords being incorrectly highlighted as function calls

### DIFF
--- a/syntaxes/.prettierrc.json
+++ b/syntaxes/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+	"useTabs": false,
+	"tabWidth": 4
+}

--- a/syntaxes/.prettierrc.json
+++ b/syntaxes/.prettierrc.json
@@ -1,4 +1,4 @@
 {
-	"useTabs": false,
-	"tabWidth": 4
+    "useTabs": false,
+    "tabWidth": 4
 }

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -221,6 +221,9 @@
                     "include": "#keywords"
                 },
                 {
+                    "include": "#control_flow"
+                },
+                {
                     "include": "#function-call"
                 },
                 {

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -155,6 +155,25 @@ export(test_enum) var enum_variable = test_enum.VALUE_1
 
 # ------------------------------------------------------------------------------
 
+func if_test():
+	var some_bool := true
+
+	if some_bool:
+		pass
+
+	if (some_bool):
+		pass
+	elif !some_bool:
+		pass
+	elif !(some_bool):
+		pass
+	elif (some_bool):
+		pass
+	else:
+		pass
+
+# ------------------------------------------------------------------------------
+
 class InnerClass:
 	var some_var = 100
 	var dict = {

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -158,20 +158,20 @@ export(test_enum) var enum_variable = test_enum.VALUE_1
 func if_test():
 	var some_bool := true
 
-	if some_bool:
-		pass
-
 	while some_bool:
 		pass
 	while (some_bool):
 		pass
 
+	if some_bool:
+		return some_bool
+
 	if (some_bool):
-		pass
+		return (some_bool)
 	elif !some_bool:
-		pass
+		return !some_bool
 	elif !(some_bool):
-		pass
+		return !(some_bool)
 	elif (some_bool):
 		pass
 	else:

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -161,6 +161,11 @@ func if_test():
 	if some_bool:
 		pass
 
+	while some_bool:
+		pass
+	while (some_bool):
+		pass
+
 	if (some_bool):
 		pass
 	elif !some_bool:


### PR DESCRIPTION
Some instances of keywords followed by an open paren were being incorrectly highlighted as a function call. 

I also added a `.prettierrc.json` config file to the syntaxes directory. I would really like to reach the point where the entire project has automatic formatting preconfigured, maybe including precommit hooks, but I'm starting with the folder I've touched the most.

(Also: hopefully I got all the trailing newlines correct this time...)

<details>
<summary>Screenshot</summary>

![Code_k7imWQpXnI](https://user-images.githubusercontent.com/18042232/165643105-f4fe38e2-80dc-48ee-8a11-89e7a5405618.png)


</details>