### PR TITLE
feature: enhanced comments to allow for @annotation for better readability

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -104,9 +104,50 @@
             "captures": {
                 "1": {
                     "name": "punctuation.definition.comment.number-sign.gdscript"
+                },
+                "2": {
+                    "name": "punctuation.definition.comment.number-sign.gdscript",
+                    "patterns": [
+                        {
+                            "_comment": "# @annotation id {type,...} description",
+                            "match": "(@[a-z_]+) ([a-zA-Z0-9_]+) \\{([^}]+)\\}(|\\s+.+)",
+                            "captures": {
+                                "1": {
+                                    "name": "storage.type.function.gdscript"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.gdscript"
+                                },
+                                "3": {
+                                    "name": "class.other.gdscript"
+                                }
+                            }
+                        },
+                        {
+                            "_comment": "# @annotation {type,...} description",
+                            "match": "(@[a-z_]+) \\{([^}]+)\\}(|\\s+.+)",
+                            "captures": {
+                                "1": {
+                                    "name": "storage.type.function.gdscript"
+                                },
+                                "2": {
+                                    "name": "class.other.gdscript"
+                                }
+                            }
+                        },
+                        {
+                            "_comment": "# @annotation description",
+                            "match": "(@[a-z_]+)(|\\s+.+)",
+                            "captures": {
+                                "1": {
+                                    "name": "storage.type.function.gdscript"
+                                }
+                            }
+                        }
+                    ]
                 }
             },
-            "match": "(#).*$\\n?",
+            "match": "(#)\\s*(.*)$\\n?",
             "name": "comment.line.number-sign.gdscript"
         },
         "strings": {


### PR DESCRIPTION
the following comment syntax is now supported:

- `# @annotation description`
- `# @annotation {type[,...]} description`
- `# @annotation id {type[,...]} description`

which looks like this on my machine:

<img width="287" alt="Screen Shot 2022-05-01 at 5 57 55 PM" src="https://user-images.githubusercontent.com/5303591/166166196-d2f7e459-3420-4449-92bd-bef8fbacb57b.png">

i find this very helpful for documenting signals and arguments whose type can't be explicitly defined (due to potential circular dependency)