### PR TITLE
Mention that the Godot editor must be running in connection error message

### DIFF
--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -240,7 +240,7 @@ export class GodotTools {
 
 		let host = get_configuration("gdscript_lsp_server_host", "localhost");
 		let port = get_configuration("gdscript_lsp_server_port", 6008);
-		let message = `Couldn't connect to the GDScript language server at ${host}:${port}`;
+		let message = `Couldn't connect to the GDScript language server at ${host}:${port}. Is the Godot editor running?`;
 		vscode.window.showErrorMessage(message, 'Open Godot Editor', 'Retry', 'Ignore').then(item => {
 			if (item == 'Retry') {
 				this.reconnection_attempts = 0;


### PR DESCRIPTION
See https://github.com/godotengine/godot-vscode-plugin/issues/356.

@DaelonSuzuka Could you take a look to make sure the message is well-worded?