### PR TITLE
Add workspace file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test
 configurations/tmp.txt
 configurations/test.py
 .vscode-test
+workspace.code-workspace


### PR DESCRIPTION
Having a `workspace.code-workspace` file in the root of this workspace will cause the Extension Development Host to automatically open the specified folder. 

I'm adding this to the gitignore instead of committing a workspace file directly because I often want to specify a real project for testing, and that local path obviously shouldn't be committed.

This workspace file will cause the Extension Development Host to open the godot-tools folder as a workspace. Simply replace the path with a path to a real project to open that instead.

```json
{
	"folders": [
		{
			"path": "."
		}
	]
}
```