### PR TITLE
Add "additional options" to launch debugger with

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,6 +273,11 @@
 								"type": "string",
 								"description": "Relative path from the godot.project file to a TSCN file. If launch_scene and launch_game_instance are true, and this file is defined, will launch the specified file instead of looking for an active TSCN file.",
 								"default": ""
+							},
+							"additional_options":{
+								"type":"string",
+								"description": "Additional command line arguments.",
+								"default":""
 							}
 						}
 					}
@@ -286,7 +291,8 @@
 						"port": 6007,
 						"address": "127.0.0.1",
 						"launch_game_instance": true,
-						"launch_scene": false
+						"launch_scene": false,
+						"additional_options":""
 					}
 				],
 				"configurationSnippets": [
@@ -300,7 +306,8 @@
 							"port": 6007,
 							"address": "127.0.0.1",
 							"launch_game_instance": true,
-							"launch_scene": false
+							"launch_scene": false,
+							"additional_options":""
 						}
 					}
 				]

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -22,6 +22,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	port: number;
 	project: string;
 	scene_file: string;
+	additional_options: string;
 }
 
 export class GodotDebugSession extends LoggingDebugSession {
@@ -235,6 +236,8 @@ export class GodotDebugSession extends LoggingDebugSession {
 			args.port,
 			args.launch_game_instance,
 			args.launch_scene,
+			args.scene_file,
+			args.additional_options,
 			get_configuration("scene_file_config", "") || args.scene_file,
 		]);
 

--- a/src/debugger/debugger_context.ts
+++ b/src/debugger/debugger_context.ts
@@ -185,6 +185,7 @@ class GodotConfigurationProvider implements DebugConfigurationProvider {
 				config.address = "127.0.0.1";
 				config.launch_game_instance = true;
 				config.launch_scene = false;
+				config.additional_options = "";
 			}
 		}
 

--- a/src/debugger/mediator.ts
+++ b/src/debugger/mediator.ts
@@ -32,7 +32,7 @@ export class Mediator {
 					let message_content: string = line[0];
 					//let message_kind: number = line[1];
 
-					// OutputChannel doesn't give a way to distinguish between a 
+					// OutputChannel doesn't give a way to distinguish between a
 					// regular string (message_kind == 0) and an error string (message_kind == 1).
 
 					this.output.appendLine(message_content);
@@ -149,6 +149,7 @@ export class Mediator {
 					parameters[3],
 					parameters[4],
 					parameters[5],
+					parameters[6],
 					this.debug_data
 				);
 				break;

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -107,7 +107,6 @@ export class ServerController {
 			if (force_visible_collision_shapes) {
 				executable_line += " --debug-collisions";
 			}
-
 			if (force_visible_nav_mesh) {
 				executable_line += " --debug-navigation";
 			}
@@ -120,22 +119,18 @@ export class ServerController {
 				}
 				executable_line += ` "${filename}"`;
 			}
-
 			if(additional_options){
 				executable_line += " " + additional_options;
 			}
-
 			executable_line += this.breakpoint_string(
 				debug_data.get_all_breakpoints(),
 				project_path
 			);
-
 			let godot_exec = cp.exec(executable_line, (error) => {
 				if (!this.terminated) {
 					window.showErrorMessage(`Failed to launch Godot instance: ${error}`);
 				}
 			});
-
 			this.godot_pid = godot_exec.pid;
 		}
 

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -92,6 +92,7 @@ export class ServerController {
 		launch_instance: boolean,
 		launch_scene: boolean,
 		scene_file: string | undefined,
+		additional_options: string | undefined,
 		debug_data: GodotDebugData
 	) {
 		this.debug_data = debug_data;
@@ -102,13 +103,16 @@ export class ServerController {
 			const force_visible_nav_mesh = utils.get_configuration("force_visible_nav_mesh", false);
 			let visible_collision_shapes_param = "";
 			let visible_nav_mesh_param = "";
+
 			if (force_visible_collision_shapes) {
 				visible_collision_shapes_param = " --debug-collisions";
 			}
+
 			if (force_visible_nav_mesh) {
 				visible_nav_mesh_param = " --debug-navigation";
 			}
-			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}""${visible_collision_shapes_param}""${visible_nav_mesh_param}`;
+
+			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}${visible_collision_shapes_param}${visible_nav_mesh_param}`;
 			if (launch_scene) {
 				let filename = "";
 				if (scene_file) {
@@ -118,15 +122,22 @@ export class ServerController {
 				}
 				executable_line += ` "${filename}"`;
 			}
+
+			if(additional_options){
+				executable_line += " " + additional_options;
+			}
+
 			executable_line += this.breakpoint_string(
 				debug_data.get_all_breakpoints(),
 				project_path
 			);
+
 			let godot_exec = cp.exec(executable_line, (error) => {
 				if (!this.terminated) {
 					window.showErrorMessage(`Failed to launch Godot instance: ${error}`);
 				}
 			});
+
 			this.godot_pid = godot_exec.pid;
 		}
 


### PR DESCRIPTION
This PR implements #362.  

This allows other VSCode plugins to fully leverage the debugger interface that this plugin provides.  `additional_options` lets any other plugin specify whatever arguments it wants to send to the debugger.

### Usage Example
```
class GodotDebugConfiguration implements vscode.DebugConfiguration{
    public type = "godot";
    public name = "Debug Godot";
    public request = "launch";
    public project = "${workspaceFolder}";
    public port = 6007;
    public address = "127.0.0.1";
    public launch_game_instance = true;
    public launch_scene = false;
    public additional_options = "";
}

private runGutThroughDebugger(options:string = ''){
    let config = new GodotDebugConfiguration();
    config.additional_options = "-s \"res://addons/gut/gut_cmdln.gd\"";
    vscode.debug.startDebugging(undefined, config);
}
```
