### PR TITLE
Fix regression in launching debugger

### DIFF
--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -103,12 +103,12 @@ export class ServerController {
 
 			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}`;
 
-            if (force_visible_collision_shapes) {
-                executable_line += ` --debug-collisions`;
-            }
-            if (force_visible_nav_mesh) {
-                executable_line += ` --debug-navigation`;
-            }
+		if (force_visible_collision_shapes) {
+			executable_line += " --debug-collisions";
+		}
+		if (force_visible_nav_mesh) {
+			executable_line += " --debug-navigation";
+		}
 			if (launch_scene) {
 				let filename = "";
 				if (scene_file) {

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -103,12 +103,12 @@ export class ServerController {
 
 			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}`;
 
-		if (force_visible_collision_shapes) {
-			executable_line += " --debug-collisions";
-		}
-		if (force_visible_nav_mesh) {
-			executable_line += " --debug-navigation";
-		}
+			if (force_visible_collision_shapes) {
+				executable_line += " --debug-collisions";
+			}
+			if (force_visible_nav_mesh) {
+				executable_line += " --debug-navigation";
+			}
 			if (launch_scene) {
 				let filename = "";
 				if (scene_file) {

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -100,15 +100,15 @@ export class ServerController {
 			let godot_path: string = utils.get_configuration("editor_path", "godot");
 			const force_visible_collision_shapes = utils.get_configuration("force_visible_collision_shapes", false);
 			const force_visible_nav_mesh = utils.get_configuration("force_visible_nav_mesh", false);
-			let visible_collision_shapes_param = "";
-			let visible_nav_mesh_param = "";
-			if (force_visible_collision_shapes) {
-				visible_collision_shapes_param = " --debug-collisions";
-			}
-			if (force_visible_nav_mesh) {
-				visible_nav_mesh_param = " --debug-navigation";
-			}
-			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}""${visible_collision_shapes_param}""${visible_nav_mesh_param}`;
+
+			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}`;
+
+            if (force_visible_collision_shapes) {
+                executable_line += ` --debug-collisions`;
+            }
+            if (force_visible_nav_mesh) {
+                executable_line += ` --debug-navigation`;
+            }
 			if (launch_scene) {
 				let filename = "";
 				if (scene_file) {


### PR DESCRIPTION
A previous commit assembled the `executable_line` variable incorrectly, and added redundant local variables.

This is a fix for #370. I can confirm that in `1.3,0`, launching is slower and breakpoints don't stop. This change fixes that regression.

However, on `1.2.0`, `1.3.0`, _and_ this patch, continuing or stepping over/in/out of a stopped breakpoint doesn't seem to do anything. I have to admit I've never used the VSCode debugger until now, so I'm not sure if this is a known issue, a problem with my configuration, or another regression.
