### PR TITLE
print statements emit from debug console as opposed to output

### DIFF
--- a/src/debugger/mediator.ts
+++ b/src/debugger/mediator.ts
@@ -1,5 +1,5 @@
 import { ServerController } from "./server_controller";
-import { window, OutputChannel } from "vscode";
+import { debug } from "vscode";
 import { GodotDebugSession } from "./debug_session";
 import { StoppedEvent, TerminatedEvent } from "vscode-debugadapter";
 import { GodotDebugData, GodotVariable } from "./debug_runtime";
@@ -12,18 +12,15 @@ export class Mediator {
 		(class_name: string, variable: GodotVariable) => void
 	> = new Map();
 	private static session?: GodotDebugSession;
-	private static first_output = false;
-	private static output: OutputChannel = window.createOutputChannel("Godot");
+	private static did_first_output = false;
 
 	private constructor() {}
 
 	public static notify(event: string, parameters: any[] = []) {
 		switch (event) {
 			case "output":
-				if (!this.first_output) {
-					this.first_output = true;
-					this.output.show(true);
-					this.output.clear();
+				if (!this.did_first_output) {
+					this.did_first_output = true;
 					this.controller?.send_request_scene_tree_command();
 				}
 
@@ -31,11 +28,10 @@ export class Mediator {
 				lines.forEach((line) => {
 					let message_content: string = line[0];
 					//let message_kind: number = line[1];
-
-					// OutputChannel doesn't give a way to distinguish between a 
+					
+					// DebugConsole doesn't give a way to distinguish between a 
 					// regular string (message_kind == 0) and an error string (message_kind == 1).
-
-					this.output.appendLine(message_content);
+					debug.activeDebugConsole.appendLine(message_content);
 				});
 				break;
 
@@ -141,7 +137,7 @@ export class Mediator {
 				break;
 
 			case "start":
-				this.first_output = false;
+				this.did_first_output = false;
 				this.controller?.start(
 					parameters[0],
 					parameters[1],


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot-vscode-plugin/issues/382

All I did was was move the print statement from the Output window to the Debug Console. The Debug Console stays up to date by default and will collapse similar values. I'm no expert, but it seems to me that this is an issue with VS Code itself. 

I'm happy with this fix for my needs, but I understand that some people might be used to print statement showing up in the Output window. So feedback is welcome.

Oh I also changed "first_output" to "did_first_output". Which is wholly unrelated, I just that made it easier to understand.

Below is a gif exhibiting the new behavior:

![gd_debug_console](https://user-images.githubusercontent.com/30502195/174351867-32e9476b-758c-4656-bae1-2580c5649e1d.gif)

This is my test script seen in the gif:

```gdscript
extends Node2D

var cycle: int = 1
var sprite = Sprite.new()
var direction: int = 1
var moniker: String = "Zachary"

func _ready():
	print("Ready!")
	sprite.texture = load("res://icon.png")
	sprite.position.x = 100
	sprite.position.y = 200
	add_child(sprite)
	
func _process(delta):
	sprite.position.x += 500 * direction * delta
	if sprite.position.x >= 640:
		print("BOUNCE RIGHT")
		direction = -1
	if (sprite.position.x <= 0):
		print("BOUNCE LEFT")
		direction = 1
	
	print(cycle)

```