### PR TITLE
Debugger fixes for Godot 4.0

### DIFF
--- a/src/debugger/commands/command.ts
+++ b/src/debugger/commands/command.ts
@@ -1,7 +1,5 @@
 import { Mediator } from "../mediator";
 
 export abstract class Command {
-	public param_count: number = -1;
-
 	public abstract trigger(parameters: any[]): void;
 }

--- a/src/debugger/commands/command_parser.ts
+++ b/src/debugger/commands/command_parser.ts
@@ -18,13 +18,13 @@ export class CommandParser {
 			},
 		],
 		[
-			"message:scene_tree",
+			"scene:scene_tree",
 			function () {
 				return new CommandMessageSceneTree();
 			},
 		],
 		[
-			"message:inspect_object",
+			"scene:inspect_object",
 			function () {
 				return new CommandMessageInspectObject();
 			},
@@ -77,7 +77,7 @@ export class CommandParser {
 	}
 
 	public make_request_scene_tree_command(): Buffer {
-		return this.build_buffered_command("request_scene_tree");
+		return this.build_buffered_command("scene:request_scene_tree");
 	}
 
 	public make_send_breakpoint_command(path_to: string, line: number): Buffer {

--- a/src/debugger/commands/command_parser.ts
+++ b/src/debugger/commands/command_parser.ts
@@ -96,7 +96,7 @@ export class CommandParser {
 		label: string,
 		new_parsed_value: any
 	): Buffer {
-		return this.build_buffered_command("set_object_property", [
+		return this.build_buffered_command("scene:set_object_property", [
 			object_id,
 			label,
 			new_parsed_value,

--- a/src/debugger/commands/command_parser.ts
+++ b/src/debugger/commands/command_parser.ts
@@ -2,6 +2,7 @@ import { Command } from "./command";
 import { CommandDebugEnter } from "./commands/command_debug_enter";
 import { CommandOutput } from "./commands/command_output";
 import { CommandStackDump } from "./commands/command_stack_dump";
+import { CommandStackFrameVar } from "./commands/command_stack_frame_var";
 import { CommandStackFrameVars } from "./commands/command_stack_frame_vars";
 import { CommandNull } from "./commands/command_null";
 import { CommandMessageSceneTree } from "./commands/command_message_scene_tree";
@@ -39,6 +40,12 @@ export class CommandParser {
 			"stack_frame_vars",
 			function () {
 				return new CommandStackFrameVars();
+			},
+		],
+		[
+			"stack_frame_var",
+			function () {
+				return new CommandStackFrameVar();
 			},
 		],
 		[

--- a/src/debugger/commands/command_parser.ts
+++ b/src/debugger/commands/command_parser.ts
@@ -108,24 +108,20 @@ export class CommandParser {
 		return this.build_buffered_command("step");
 	}
 
-	public parse_message(dataset: any[]) {
-		while (dataset && dataset.length > 0) {
-			let command: Command;
-			const command_name = dataset.shift();
-			if (command_name && this.commands.has(command_name)) {
-				command = this.commands.get(command_name)();
-			} else {
-				command = new CommandNull();
-			}
+	public parse_message(command_name: string, parameters: any[]) {
+		let command: Command;
+		if (command_name && this.commands.has(command_name)) {
+			command = this.commands.get(command_name)();
+		} else {
+			command = new CommandNull();
+		}
 
-			const parameters = dataset.shift();
-			try {
-				command.trigger(parameters);
-			} catch (e) {
-				// FIXME: Catch exception during trigger command: TypeError: class_name.replace is not a function
-				// class_name is the key of Mediator.inspect_callbacks
-				console.error("Catch exception during trigger command: " + e);
-			}
+		try {
+			command.trigger(parameters);
+		} catch (e) {
+			// FIXME: Catch exception during trigger command: TypeError: class_name.replace is not a function
+			// class_name is the key of Mediator.inspect_callbacks
+			console.error("Catch exception during trigger command: " + e);
 		}
 	}
 

--- a/src/debugger/commands/command_parser.ts
+++ b/src/debugger/commands/command_parser.ts
@@ -54,13 +54,7 @@ export class CommandParser {
 			},
 		],
 	]);
-	private current_command?: Command;
 	private encoder = new VariantEncoder();
-	private parameters: any[] = [];
-
-	public has_command() {
-		return this.current_command;
-	}
 
 	public make_break_command(): Buffer {
 		return this.build_buffered_command("break");
@@ -116,54 +110,27 @@ export class CommandParser {
 
 	public parse_message(dataset: any[]) {
 		while (dataset && dataset.length > 0) {
-			if (this.current_command) {
-				this.parameters.push(dataset.shift());
-				if (this.current_command.param_count !== -1) {
-					if (this.current_command.param_count === this.parameters.length) {
-						try {
-							this.current_command.trigger(this.parameters);
-						} catch (e) {
-							// FIXME: Catch exception during trigger command: TypeError: class_name.replace is not a function
-							// class_name is the key of Mediator.inspect_callbacks
-							console.error("Catch exception during trigger command: " + e);
-						} finally {
-							this.current_command = undefined;
-							this.parameters = [];
-						}
-					} else if(this.current_command.param_count < this.parameters.length) {
-						// we debugged that an exception occures during this.current_command.trigger(this.parameters)
-						// because we do not understand the root cause of the exception, we set the current command to undefined
-						// to avoid a infinite loop of parse_message(...)
-						this.current_command = undefined
-						this.parameters = [];
-						console.log("Exception not catched. Reset current_command to avoid infinite loop.")
-					}
-				} else {
-					this.current_command.param_count = this.parameters.shift();
-					if (this.current_command.param_count === 0) {
-						this.current_command.trigger([]);
-						this.current_command = undefined;
-					}
-				}
+			let command: Command;
+			const command_name = dataset.shift();
+			if (command_name && this.commands.has(command_name)) {
+				command = this.commands.get(command_name)();
 			} else {
-				let data = dataset.shift();
-				if (data && this.commands.has(data)) {
-					this.current_command = this.commands.get(data)();
-				} else {
-					this.current_command = new CommandNull();
-				}
+				command = new CommandNull();
+			}
+
+			const parameters = dataset.shift();
+			try {
+				command.trigger(parameters);
+			} catch (e) {
+				// FIXME: Catch exception during trigger command: TypeError: class_name.replace is not a function
+				// class_name is the key of Mediator.inspect_callbacks
+				console.error("Catch exception during trigger command: " + e);
 			}
 		}
 	}
 
 	private build_buffered_command(command: string, parameters?: any[]) {
-		let command_array: any[] = [command];
-		if (parameters) {
-			parameters.forEach((param) => {
-				command_array.push(param);
-			});
-		}
-
+		let command_array: any[] = [command, parameters ?? []];
 		let buffer = this.encoder.encode_variant(command_array);
 		return buffer;
 	}

--- a/src/debugger/commands/commands/command_stack_dump.ts
+++ b/src/debugger/commands/commands/command_stack_dump.ts
@@ -4,14 +4,15 @@ import { GodotStackFrame } from "../../debug_runtime";
 
 export class CommandStackDump extends Command {
 	public trigger(parameters: any[]) {
-		let frames: GodotStackFrame[] = parameters.map((sf, i) => {
-			return {
-				id: i,
-				file: sf.get("file"),
-				function: sf.get("function"),
-				line: sf.get("line"),
-			};
-		});
+		let frames: GodotStackFrame[] = [];
+		for (let i = 1; i < parameters.length; i += 3) {
+			frames.push({
+				id: frames.length,
+				file: parameters[i + 0],
+				line: parameters[i + 1],
+				function: parameters[i + 2],
+			});
+		}
 		Mediator.notify("stack_dump", frames);
 	}
 }

--- a/src/debugger/commands/commands/command_stack_frame_var.ts
+++ b/src/debugger/commands/commands/command_stack_frame_var.ts
@@ -1,0 +1,11 @@
+import { Command } from "../command";
+import { Mediator } from "../../mediator";
+
+export class CommandStackFrameVar extends Command {
+	public trigger(parameters: any[]) {
+		let name = parameters[0];
+		let type = parameters[1];
+		let value = parameters[2];
+		Mediator.notify("stack_frame_var", [name, value, type]);
+	}
+}

--- a/src/debugger/commands/commands/command_stack_frame_vars.ts
+++ b/src/debugger/commands/commands/command_stack_frame_vars.ts
@@ -3,29 +3,7 @@ import { Mediator } from "../../mediator";
 
 export class CommandStackFrameVars extends Command {
 	public trigger(parameters: any[]) {
-		let globals: any[] = [];
-		let locals: any[] = [];
-		let members: any[] = [];
-
-		let local_count = parameters[0] * 2;
-		let member_count = parameters[1 + local_count] * 2;
-		let global_count = parameters[2 + local_count + member_count] * 2;
-
-		if (local_count > 0) {
-			let offset = 1;
-			locals = parameters.slice(offset, offset + local_count);
-		}
-
-		if (member_count > 0) {
-			let offset = 2 + local_count;
-			members = parameters.slice(offset, offset + member_count);
-		}
-
-		if (global_count > 0) {
-			let offset = 3 + local_count + member_count;
-			globals = parameters.slice(offset, offset + global_count);
-		}
-
-		Mediator.notify("stack_frame_vars", [locals, members, globals]);
+		let amount = parameters[0];
+		Mediator.notify("stack_frame_vars", [amount]);
 	}
 }

--- a/src/debugger/debug_session.ts
+++ b/src/debugger/debug_session.ts
@@ -386,6 +386,14 @@ export class GodotDebugSession extends LoggingDebugSession {
 		response: DebugProtocol.VariablesResponse,
 		args: DebugProtocol.VariablesArguments
 	) {
+		if (!this.all_scopes) {
+			response.body = {
+				variables: []
+			};
+			this.sendResponse(response);
+			return;
+		}
+
 		let reference = this.all_scopes[args.variablesReference];
 		let variables: DebugProtocol.Variable[];
 

--- a/src/debugger/mediator.ts
+++ b/src/debugger/mediator.ts
@@ -14,6 +14,12 @@ export class Mediator {
 	private static session?: GodotDebugSession;
 	private static first_output = false;
 	private static output: OutputChannel = window.createOutputChannel("Godot");
+	private static partial_stack_vars = {
+		locals: [] as GodotVariable[],
+		members: [] as GodotVariable[],
+		globals: [] as GodotVariable[],
+		remaining: 0,
+	};
 
 	private constructor() {}
 
@@ -94,7 +100,11 @@ export class Mediator {
 				break;
 
 			case "stack_frame_vars":
-				this.do_stack_frame_vars(parameters[0], parameters[1], parameters[2]);
+				this.partial_stack_vars.remaining = parameters[0];
+				break;
+
+			case "stack_frame_var":
+				this.do_stack_frame_var(parameters[0], parameters[1], parameters[2]);
 				break;
 
 			case "remove_breakpoint":
@@ -215,48 +225,42 @@ export class Mediator {
 		sub_values?.forEach((sva) => this.build_sub_values(sva));
 	}
 
-	private static do_stack_frame_vars(
-		locals: any[],
-		members: any[],
-		globals: any[]
+	private static do_stack_frame_var(
+		name: string,
+		value: any,
+		/** 0 = locals, 1 = members, 2 = globals */
+		type: number
 	) {
-		let locals_out: GodotVariable[] = [];
-		let members_out: GodotVariable[] = [];
-		let globals_out: GodotVariable[] = [];
-
-		for (
-			let i = 0;
-			i < locals.length + members.length + globals.length;
-			i += 2
-		) {
-			const name =
-				i < locals.length
-					? locals[i]
-					: i < members.length + locals.length
-					? members[i - locals.length]
-					: globals[i - locals.length - members.length];
-
-			const value =
-				i < locals.length
-					? locals[i + 1]
-					: i < members.length + locals.length
-					? members[i - locals.length + 1]
-					: globals[i - locals.length - members.length + 1];
-
-			let variable: GodotVariable = {
-				name: name,
-				value: value,
-			};
-
-			this.build_sub_values(variable);
-
-			i < locals.length
-				? locals_out.push(variable)
-				: i < members.length + locals.length
-				? members_out.push(variable)
-				: globals_out.push(variable);
+		if (this.partial_stack_vars.remaining === 0) {
+			throw new Error('More stack frame variables were sent than expected.');
 		}
 
-		this.session?.set_scopes(locals_out, members_out, globals_out);
+		let variable: GodotVariable = {
+			name,
+			value,
+		};
+		this.build_sub_values(variable);
+
+		let type_name;
+		switch (type) {
+			case 0:
+				type_name = "locals";
+				break;
+			case 1:
+				type_name = "members";
+				break;
+			case 2:
+				type_name = "globals";
+				break;
+		}
+		this.partial_stack_vars[type_name].push(variable);
+		this.partial_stack_vars.remaining--;
+
+		if (this.partial_stack_vars.remaining === 0) {
+			this.session?.set_scopes(this.partial_stack_vars.locals, this.partial_stack_vars.members, this.partial_stack_vars.globals);
+			this.partial_stack_vars.locals = [];
+			this.partial_stack_vars.members = [];
+			this.partial_stack_vars.globals = [];
+		}
 	}
 }

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -100,8 +100,9 @@ export class ServerController {
 			let godot_path: string = utils.get_configuration("editor_path", "godot");
 			const force_visible_collision_shapes = utils.get_configuration("force_visible_collision_shapes", false);
 			const force_visible_nav_mesh = utils.get_configuration("force_visible_nav_mesh", false);
+			const protocol = utils.get_configuration("gdscript_lsp_server_protocol", "tcp");
 
-			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug tcp://${address}:${port}`;
+			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${protocol}://${address}:${port}`;
 
 			if (force_visible_collision_shapes) {
 				executable_line += " --debug-collisions";

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -207,6 +207,11 @@ export class ServerController {
 	public trigger_breakpoint(stack_frames: GodotStackFrame[]) {
 		let continue_stepping = false;
 		let stack_count = stack_frames.length;
+		if (stack_count === 0) {
+			// Engine code is being executed, no user stack trace
+			Mediator.notify("stopped_on_breakpoint", [[]]);
+			return;
+		}
 
 		let file = stack_frames[0].file.replace(
 			"res://",

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -101,7 +101,7 @@ export class ServerController {
 			const force_visible_collision_shapes = utils.get_configuration("force_visible_collision_shapes", false);
 			const force_visible_nav_mesh = utils.get_configuration("force_visible_nav_mesh", false);
 
-			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug ${address}:${port}`;
+			let executable_line = `"${godot_path}" --path "${project_path}" --remote-debug tcp://${address}:${port}`;
 
 			if (force_visible_collision_shapes) {
 				executable_line += " --debug-collisions";
@@ -147,7 +147,7 @@ export class ServerController {
 				let buffers = this.split_buffers(buffer);
 				while (buffers.length > 0) {
 					let sub_buffer = buffers.shift();
-					let data = this.decoder.get_dataset(sub_buffer, 0).slice(1);
+					let data = this.decoder.get_dataset(sub_buffer, 0)[1];
 					this.commands.parse_message(data);
 				}
 			});

--- a/src/debugger/server_controller.ts
+++ b/src/debugger/server_controller.ts
@@ -148,7 +148,7 @@ export class ServerController {
 				while (buffers.length > 0) {
 					let sub_buffer = buffers.shift();
 					let data = this.decoder.get_dataset(sub_buffer, 0)[1];
-					this.commands.parse_message(data);
+					this.commands.parse_message(data[0], data[1]);
 				}
 			});
 

--- a/src/debugger/variables/variant_decoder.ts
+++ b/src/debugger/variables/variant_decoder.ts
@@ -23,6 +23,9 @@ import {
 	Projection,
 	ENCODE_FLAG_64,
 	ENCODE_FLAG_OBJECT_AS_ID,
+	RID,
+	Callable,
+	Signal,
 } from "./variants";
 
 export class VariantDecoder {
@@ -126,7 +129,7 @@ export class VariantDecoder {
 			case GDScriptTypes.NODE_PATH:
 				return this.decode_NodePath(model);
 			case GDScriptTypes.RID:
-				return undefined; // TODO
+				return this.decode_RID(model);
 			case GDScriptTypes.OBJECT:
 				if (type & ENCODE_FLAG_OBJECT_AS_ID) {
 					return this.decode_Object_id(model);
@@ -134,9 +137,9 @@ export class VariantDecoder {
 					return this.decode_Object(model);
 				}
 			case GDScriptTypes.CALLABLE:
-				return undefined; // TODO
+				return this.decode_Callable(model);
 			case GDScriptTypes.SIGNAL:
-				return undefined; // TODO
+				return this.decode_Signal(model);
 			case GDScriptTypes.DICTIONARY:
 				return this.decode_Dictionary(model);
 			case GDScriptTypes.ARRAY:
@@ -332,6 +335,20 @@ export class VariantDecoder {
 		let id = this.decode_UInt64(model);
 
 		return new ObjectId(id);
+	}
+
+	private decode_RID(model: BufferModel) {
+		let id = this.decode_UInt64(model);
+
+		return new RID(id);
+	}
+
+	private decode_Callable(model: BufferModel) {
+		return new Callable();
+	}
+
+	private decode_Signal(model: BufferModel) {
+		return new Signal(this.decode_String(model), this.decode_Object_id(model));
 	}
 
 	private decode_Planef(model: BufferModel) {

--- a/src/debugger/variables/variant_decoder.ts
+++ b/src/debugger/variables/variant_decoder.ts
@@ -435,14 +435,25 @@ export class VariantDecoder {
 	}
 
 	private decode_UInt64(model: BufferModel) {
-		let hi = model.buffer.readUInt32LE(model.offset);
-		let lo = model.buffer.readUInt32LE(model.offset + 4);
-
-		let u = BigInt((hi << 32) | lo);
+		const first = model.buffer[model.offset];
+		const last = model.buffer[model.offset + 7];
+		const val =
+			model.buffer[model.offset + 4] +
+			model.buffer[model.offset + 5] * 2 ** 8 +
+			model.buffer[model.offset + 6] * 2 ** 16 +
+			(last << 24); // Overflow
+		const result = (
+			(BigInt(val) << BigInt(32)) +
+			BigInt(
+				first +
+					model.buffer[model.offset + 1] * 2 ** 8 +
+					model.buffer[model.offset + 2] * 2 ** 16 +
+					model.buffer[model.offset + 3] * 2 ** 24,
+			)
+		);
 		model.len -= 8;
 		model.offset += 8;
-
-		return u;
+		return result;
 	}
 
 	private decode_Vector2(model: BufferModel) {

--- a/src/debugger/variables/variant_decoder.ts
+++ b/src/debugger/variables/variant_decoder.ts
@@ -21,6 +21,8 @@ import {
 	Vector4i,
 	StringName,
 	Projection,
+	ENCODE_FLAG_64,
+	ENCODE_FLAG_OBJECT_AS_ID,
 } from "./variants";
 
 export class VariantDecoder {
@@ -30,49 +32,93 @@ export class VariantDecoder {
 			case GDScriptTypes.BOOL:
 				return this.decode_UInt32(model) !== 0;
 			case GDScriptTypes.INT:
-				if (type & (1 << 16)) {
+				if (type & ENCODE_FLAG_64) {
 					return this.decode_Int64(model);
 				} else {
 					return this.decode_Int32(model);
 				}
 			case GDScriptTypes.FLOAT:
-				if (type & (1 << 16)) {
-					return this.decode_Double(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Float64(model);
 				} else {
 					return this.decode_Float32(model);
 				}
 			case GDScriptTypes.STRING:
 				return this.decode_String(model);
 			case GDScriptTypes.VECTOR2:
-				return this.decode_Vector2(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Vector2d(model);
+				} else {
+					return this.decode_Vector2f(model);
+				}
 			case GDScriptTypes.VECTOR2I:
 				return this.decode_Vector2i(model);
 			case GDScriptTypes.RECT2:
-				return this.decode_Rect2(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Rect2d(model);
+				} else {
+					return this.decode_Rect2f(model);
+			}
 			case GDScriptTypes.RECT2I:
 				return this.decode_Rect2i(model);
 			case GDScriptTypes.VECTOR3:
-				return this.decode_Vector3(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Vector3d(model);
+				} else {
+					return this.decode_Vector3f(model);
+				}
 			case GDScriptTypes.VECTOR3I:
 				return this.decode_Vector3i(model);
 			case GDScriptTypes.TRANSFORM2D:
-				return this.decode_Transform2D(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Transform2Dd(model);
+				} else {
+					return this.decode_Transform2Df(model);
+				}
 			case GDScriptTypes.PLANE:
-				return this.decode_Plane(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Planed(model);
+				} else {
+					return this.decode_Planef(model);
+				}
 			case GDScriptTypes.VECTOR4:
-				return this.decode_Vector4(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Vector4d(model);
+				} else {
+					return this.decode_Vector4f(model);
+				}
 			case GDScriptTypes.VECTOR4I:
 				return this.decode_Vector4i(model);
 			case GDScriptTypes.QUATERNION:
-				return this.decode_Quat(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Quaterniond(model);
+				} else {
+					return this.decode_Quaternionf(model);
+				}
 			case GDScriptTypes.AABB:
-				return this.decode_AABB(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_AABBd(model);
+				} else {
+					return this.decode_AABBf(model);
+				}
 			case GDScriptTypes.BASIS:
-				return this.decode_Basis(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Basisd(model);
+				} else {
+					return this.decode_Basisf(model);
+				}
 			case GDScriptTypes.TRANSFORM3D:
-				return this.decode_Transform3D(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Transform3Dd(model);
+				} else {
+					return this.decode_Transform3Df(model);
+				}
 			case GDScriptTypes.PROJECTION:
-				return this.decode_Projection(model);
+				if (type & ENCODE_FLAG_64) {
+					return this.decode_Projectiond(model);
+				} else {
+					return this.decode_Projectionf(model);
+				}
 			case GDScriptTypes.COLOR:
 				return this.decode_Color(model);
 			case GDScriptTypes.STRING_NAME:
@@ -82,7 +128,7 @@ export class VariantDecoder {
 			case GDScriptTypes.RID:
 				return undefined; // TODO
 			case GDScriptTypes.OBJECT:
-				if (type & (1 << 16)) {
+				if (type & ENCODE_FLAG_OBJECT_AS_ID) {
 					return this.decode_Object_id(model);
 				} else {
 					return this.decode_Object(model);
@@ -108,9 +154,17 @@ export class VariantDecoder {
 			case GDScriptTypes.PACKED_STRING_ARRAY:
 				return this.decode_PackedStringArray(model);
 			case GDScriptTypes.PACKED_VECTOR2_ARRAY:
-				return this.decode_PackedVector2Array(model);
+				if (type & ENCODE_FLAG_OBJECT_AS_ID) {
+					return this.decode_PackedVector2dArray(model);
+				} else {
+					return this.decode_PackedVector2fArray(model);
+				}
 			case GDScriptTypes.PACKED_VECTOR3_ARRAY:
-				return this.decode_PackedVector3Array(model);
+				if (type & ENCODE_FLAG_OBJECT_AS_ID) {
+					return this.decode_PackedVector3dArray(model);
+				} else {
+					return this.decode_PackedVector3fArray(model);
+				}
 			case GDScriptTypes.PACKED_COLOR_ARRAY:
 				return this.decode_PackedColorArray(model);
 			default:
@@ -139,8 +193,12 @@ export class VariantDecoder {
 		return output;
 	}
 
-	private decode_AABB(model: BufferModel) {
-		return new AABB(this.decode_Vector3(model), this.decode_Vector3(model));
+	private decode_AABBf(model: BufferModel) {
+		return new AABB(this.decode_Vector3f(model), this.decode_Vector3f(model));
+	}
+
+	private decode_AABBd(model: BufferModel) {
+		return new AABB(this.decode_Vector3d(model), this.decode_Vector3d(model));
 	}
 
 	private decode_Array(model: BufferModel) {
@@ -156,16 +214,24 @@ export class VariantDecoder {
 		return output;
 	}
 
-	private decode_Basis(model: BufferModel) {
+	private decode_Basisf(model: BufferModel) {
 		return new Basis(
-			this.decode_Vector3(model),
-			this.decode_Vector3(model),
-			this.decode_Vector3(model)
+			this.decode_Vector3f(model),
+			this.decode_Vector3f(model),
+			this.decode_Vector3f(model)
+		);
+	}
+
+	private decode_Basisd(model: BufferModel) {
+		return new Basis(
+			this.decode_Vector3d(model),
+			this.decode_Vector3d(model),
+			this.decode_Vector3d(model)
 		);
 	}
 
 	private decode_Color(model: BufferModel) {
-		let rgb = this.decode_Vector3(model);
+		let rgb = this.decode_Vector3f(model);
 		let a = this.decode_Float32(model);
 
 		return new Color(rgb.x, rgb.y, rgb.z, a);
@@ -182,15 +248,6 @@ export class VariantDecoder {
 		}
 
 		return output;
-	}
-
-	private decode_Double(model: BufferModel) {
-		let d = model.buffer.readDoubleLE(model.offset);
-
-		model.offset += 8;
-		model.len -= 8;
-
-		return d; // + (d < 0 ? -1e-10 : 1e-10);
 	}
 
 	private decode_Float32(model: BufferModel) {
@@ -277,11 +334,20 @@ export class VariantDecoder {
 		return new ObjectId(id);
 	}
 
-	private decode_Plane(model: BufferModel) {
+	private decode_Planef(model: BufferModel) {
 		let x = this.decode_Float32(model);
 		let y = this.decode_Float32(model);
 		let z = this.decode_Float32(model);
 		let d = this.decode_Float32(model);
+
+		return new Plane(x, y, z, d);
+	}
+
+	private decode_Planed(model: BufferModel) {
+		let x = this.decode_Float64(model);
+		let y = this.decode_Float64(model);
+		let z = this.decode_Float64(model);
+		let d = this.decode_Float64(model);
 
 		return new Plane(x, y, z, d);
 	}
@@ -358,27 +424,47 @@ export class VariantDecoder {
 		return output;
 	}
 
-	private decode_PackedVector2Array(model: BufferModel) {
+	private decode_PackedVector2fArray(model: BufferModel) {
 		let count = this.decode_UInt32(model);
 		let output: Vector2[] = [];
 		for (let i = 0; i < count; i++) {
-			output.push(this.decode_Vector2(model));
+			output.push(this.decode_Vector2f(model));
 		}
 
 		return output;
 	}
 
-	private decode_PackedVector3Array(model: BufferModel) {
+	private decode_PackedVector3fArray(model: BufferModel) {
 		let count = this.decode_UInt32(model);
 		let output: Vector3[] = [];
 		for (let i = 0; i < count; i++) {
-			output.push(this.decode_Vector3(model));
+			output.push(this.decode_Vector3f(model));
 		}
 
 		return output;
 	}
 
-	private decode_Quat(model: BufferModel) {
+	private decode_PackedVector2dArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: Vector2[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Vector2d(model));
+		}
+
+		return output;
+	}
+
+	private decode_PackedVector3dArray(model: BufferModel) {
+		let count = this.decode_UInt32(model);
+		let output: Vector3[] = [];
+		for (let i = 0; i < count; i++) {
+			output.push(this.decode_Vector3d(model));
+		}
+
+		return output;
+	}
+
+	private decode_Quaternionf(model: BufferModel) {
 		let x = this.decode_Float32(model);
 		let y = this.decode_Float32(model);
 		let z = this.decode_Float32(model);
@@ -387,12 +473,25 @@ export class VariantDecoder {
 		return new Quat(x, y, z, w);
 	}
 
-	private decode_Rect2(model: BufferModel) {
-		return new Rect2(this.decode_Vector2(model), this.decode_Vector2(model));
+	private decode_Quaterniond(model: BufferModel) {
+		let x = this.decode_Float64(model);
+		let y = this.decode_Float64(model);
+		let z = this.decode_Float64(model);
+		let w = this.decode_Float64(model);
+
+		return new Quat(x, y, z, w);
+	}
+
+	private decode_Rect2f(model: BufferModel) {
+		return new Rect2(this.decode_Vector2f(model), this.decode_Vector2f(model));
+	}
+
+	private decode_Rect2d(model: BufferModel) {
+		return new Rect2(this.decode_Vector2d(model), this.decode_Vector2d(model));
 	}
 
 	private decode_Rect2i(model: BufferModel) {
-		return new Rect2i(this.decode_Vector2(model), this.decode_Vector2(model));
+		return new Rect2i(this.decode_Vector2f(model), this.decode_Vector2f(model));
 	}
 
 	private decode_String(model: BufferModel) {
@@ -415,19 +514,35 @@ export class VariantDecoder {
 		return new StringName(this.decode_String(model));
 	}
 
-	private decode_Transform3D(model: BufferModel) {
-		return new Transform3D(this.decode_Basis(model), this.decode_Vector3(model));
+	private decode_Transform3Df(model: BufferModel) {
+		return new Transform3D(this.decode_Basisf(model), this.decode_Vector3f(model));
 	}
 
-	private decode_Projection(model: BufferModel) {
-		return new Projection(this.decode_Vector4(model), this.decode_Vector4(model), this.decode_Vector4(model), this.decode_Vector4(model));
+	private decode_Transform3Dd(model: BufferModel) {
+		return new Transform3D(this.decode_Basisd(model), this.decode_Vector3d(model));
 	}
 
-	private decode_Transform2D(model: BufferModel) {
+	private decode_Projectionf(model: BufferModel) {
+		return new Projection(this.decode_Vector4f(model), this.decode_Vector4f(model), this.decode_Vector4f(model), this.decode_Vector4f(model));
+	}
+
+	private decode_Projectiond(model: BufferModel) {
+		return new Projection(this.decode_Vector4d(model), this.decode_Vector4d(model), this.decode_Vector4d(model), this.decode_Vector4d(model));
+	}
+
+	private decode_Transform2Df(model: BufferModel) {
 		return new Transform2D(
-			this.decode_Vector2(model),
-			this.decode_Vector2(model),
-			this.decode_Vector2(model)
+			this.decode_Vector2f(model),
+			this.decode_Vector2f(model),
+			this.decode_Vector2f(model)
+		);
+	}
+
+	private decode_Transform2Dd(model: BufferModel) {
+		return new Transform2D(
+			this.decode_Vector2d(model),
+			this.decode_Vector2d(model),
+			this.decode_Vector2d(model)
 		);
 	}
 
@@ -461,19 +576,18 @@ export class VariantDecoder {
 		return result;
 	}
 
-	private decode_Vector2(model: BufferModel) {
+	private decode_Vector2f(model: BufferModel) {
 		let x = this.decode_Float32(model);
 		let y = this.decode_Float32(model);
 
 		return new Vector2(x, y);
 	}
 
-	private decode_Vector3(model: BufferModel) {
-		let x = this.decode_Float32(model);
-		let y = this.decode_Float32(model);
-		let z = this.decode_Float32(model);
+	private decode_Vector2d(model: BufferModel) {
+		let x = this.decode_Float64(model);
+		let y = this.decode_Float64(model);
 
-		return new Vector3(x, y, z);
+		return new Vector2(x, y);
 	}
 
 	private decode_Vector2i(model: BufferModel) {
@@ -481,6 +595,22 @@ export class VariantDecoder {
 		let y = this.decode_Int32(model);
 
 		return new Vector2i(x, y);
+	}
+
+	private decode_Vector3f(model: BufferModel) {
+		let x = this.decode_Float32(model);
+		let y = this.decode_Float32(model);
+		let z = this.decode_Float32(model);
+
+		return new Vector3(x, y, z);
+	}
+
+	private decode_Vector3d(model: BufferModel) {
+		let x = this.decode_Float64(model);
+		let y = this.decode_Float64(model);
+		let z = this.decode_Float64(model);
+
+		return new Vector3(x, y, z);
 	}
 
 	private decode_Vector3i(model: BufferModel) {
@@ -491,11 +621,20 @@ export class VariantDecoder {
 		return new Vector3i(x, y, z);
 	}
 
-	private decode_Vector4(model: BufferModel) {
+	private decode_Vector4f(model: BufferModel) {
 		let x = this.decode_Float32(model);
 		let y = this.decode_Float32(model);
 		let z = this.decode_Float32(model);
 		let w = this.decode_Float32(model);
+
+		return new Vector4(x, y, z, w);
+	}
+
+	private decode_Vector4d(model: BufferModel) {
+		let x = this.decode_Float64(model);
+		let y = this.decode_Float64(model);
+		let z = this.decode_Float64(model);
+		let w = this.decode_Float64(model);
 
 		return new Vector4(x, y, z, w);
 	}

--- a/src/debugger/variables/variant_decoder.ts
+++ b/src/debugger/variables/variant_decoder.ts
@@ -11,7 +11,7 @@ import {
 	Plane,
 	Quat,
 	Rect2,
-	Transform,
+	Transform3D,
 	Transform2D,
 	RawObject,
 	Vector2i,
@@ -20,6 +20,7 @@ import {
 	Vector4,
 	Vector4i,
 	StringName,
+	Projection,
 } from "./variants";
 
 export class VariantDecoder {
@@ -71,7 +72,7 @@ export class VariantDecoder {
 			case GDScriptTypes.TRANSFORM3D:
 				return this.decode_Transform3D(model);
 			case GDScriptTypes.PROJECTION:
-				return undefined; // TODO
+				return this.decode_Projection(model);
 			case GDScriptTypes.COLOR:
 				return this.decode_Color(model);
 			case GDScriptTypes.STRING_NAME:
@@ -415,7 +416,11 @@ export class VariantDecoder {
 	}
 
 	private decode_Transform3D(model: BufferModel) {
-		return new Transform(this.decode_Basis(model), this.decode_Vector3(model));
+		return new Transform3D(this.decode_Basis(model), this.decode_Vector3(model));
+	}
+
+	private decode_Projection(model: BufferModel) {
+		return new Projection(this.decode_Vector4(model), this.decode_Vector4(model), this.decode_Vector4(model), this.decode_Vector4(model));
 	}
 
 	private decode_Transform2D(model: BufferModel) {

--- a/src/debugger/variables/variant_encoder.ts
+++ b/src/debugger/variables/variant_encoder.ts
@@ -9,7 +9,7 @@ import {
 	Plane,
 	Quat,
 	Rect2,
-	Transform,
+	Transform3D,
 	Transform2D,
 	Vector3i,
 	Vector2i,
@@ -17,6 +17,7 @@ import {
 	Vector4i,
 	Vector4,
 	StringName,
+	Projection,
 } from "./variants";
 
 export class VariantEncoder {
@@ -119,6 +120,9 @@ export class VariantEncoder {
 					} else if (value instanceof Plane) {
 						this.encode_UInt32(GDScriptTypes.PLANE, model);
 						this.encode_Plane(value, model);
+					} else if (value instanceof Projection) {
+						this.encode_UInt32(GDScriptTypes.PROJECTION, model);
+						this.encode_Projection(value, model);
 					} else if (value instanceof Quat) {
 						this.encode_UInt32(GDScriptTypes.QUATERNION, model);
 						this.encode_Quat(value, model);
@@ -128,7 +132,7 @@ export class VariantEncoder {
 					} else if (value instanceof Basis) {
 						this.encode_UInt32(GDScriptTypes.BASIS, model);
 						this.encode_Basis(value, model);
-					} else if (value instanceof Transform) {
+					} else if (value instanceof Transform3D) {
 						this.encode_UInt32(GDScriptTypes.TRANSFORM3D, model);
 						this.encode_Transform3D(value, model);
 					} else if (value instanceof Color) {
@@ -229,7 +233,7 @@ export class VariantEncoder {
 		}
 	}
 
-	private encode_Transform3D(value: Transform, model: BufferModel) {
+	private encode_Transform3D(value: Transform3D, model: BufferModel) {
 		this.encode_Basis(value.basis, model);
 		this.encode_Vector3(value.origin, model);
 	}
@@ -238,6 +242,13 @@ export class VariantEncoder {
 		this.encode_Vector2(value.origin, model);
 		this.encode_Vector2(value.x, model);
 		this.encode_Vector2(value.y, model);
+	}
+
+	private encode_Projection(value: Projection, model: BufferModel) {
+		this.encode_Vector4(value.x, model);
+		this.encode_Vector4(value.y, model);
+		this.encode_Vector4(value.z, model);
+		this.encode_Vector4(value.w, model);
 	}
 
 	private encode_UInt32(int: number, model: BufferModel) {
@@ -419,7 +430,7 @@ export class VariantEncoder {
 							size += this.size_UInt32() * 6;
 							break;
 						case "Projection":
-							// TODO
+							size += this.size_UInt32() * 16;
 							break;
 						case "Plane":
 							size += this.size_UInt32() * 4;

--- a/src/debugger/variables/variant_encoder.ts
+++ b/src/debugger/variables/variant_encoder.ts
@@ -18,6 +18,7 @@ import {
 	Vector4,
 	StringName,
 	Projection,
+	ENCODE_FLAG_64,
 } from "./variants";
 
 export class VariantEncoder {
@@ -60,13 +61,13 @@ export class VariantEncoder {
 						this.encode_UInt32(GDScriptTypes.INT, model);
 						this.encode_UInt32(value, model);
 					} else {
-						this.encode_UInt32(GDScriptTypes.FLOAT | (1 << 16), model);
+						this.encode_UInt32(GDScriptTypes.FLOAT, model);
 						this.encode_Float32(value, model);
 					}
 				}
 				break;
 			case "bigint":
-				this.encode_UInt32(GDScriptTypes.INT | (1 << 16), model);
+				this.encode_UInt32(GDScriptTypes.INT | ENCODE_FLAG_64, model);
 				this.encode_UInt64(value, model);
 				break;
 			case "boolean":
@@ -125,7 +126,7 @@ export class VariantEncoder {
 						this.encode_Projection(value, model);
 					} else if (value instanceof Quat) {
 						this.encode_UInt32(GDScriptTypes.QUATERNION, model);
-						this.encode_Quat(value, model);
+						this.encode_Quaternion(value, model);
 					} else if (value instanceof AABB) {
 						this.encode_UInt32(GDScriptTypes.AABB, model);
 						this.encode_AABB(value, model);
@@ -203,7 +204,7 @@ export class VariantEncoder {
 		this.encode_Float32(value.d, model);
 	}
 
-	private encode_Quat(value: Quat, model: BufferModel) {
+	private encode_Quaternion(value: Quat, model: BufferModel) {
 		this.encode_Float32(value.x, model);
 		this.encode_Float32(value.y, model);
 		this.encode_Float32(value.z, model);

--- a/src/debugger/variables/variant_encoder.ts
+++ b/src/debugger/variables/variant_encoder.ts
@@ -11,6 +11,12 @@ import {
 	Rect2,
 	Transform,
 	Transform2D,
+	Vector3i,
+	Vector2i,
+	Rect2i,
+	Vector4i,
+	Vector4,
+	StringName,
 } from "./variants";
 
 export class VariantEncoder {
@@ -53,8 +59,8 @@ export class VariantEncoder {
 						this.encode_UInt32(GDScriptTypes.INT, model);
 						this.encode_UInt32(value, model);
 					} else {
-						this.encode_UInt32(GDScriptTypes.REAL | (1 << 16), model);
-						this.encode_Float(value, model);
+						this.encode_UInt32(GDScriptTypes.FLOAT | (1 << 16), model);
+						this.encode_Float32(value, model);
 					}
 				}
 				break;
@@ -80,23 +86,41 @@ export class VariantEncoder {
 					this.encode_UInt32(GDScriptTypes.DICTIONARY, model);
 					this.encode_Dictionary(value, model);
 				} else {
-					if (value instanceof Vector2) {
+					if (value instanceof Vector2i) {
+						this.encode_UInt32(GDScriptTypes.VECTOR2I, model);
+						this.encode_Vector2i(value, model);
+					} else if (value instanceof Vector2) {
 						this.encode_UInt32(GDScriptTypes.VECTOR2, model);
 						this.encode_Vector2(value, model);
+					} else if (value instanceof Rect2i) {
+						this.encode_UInt32(GDScriptTypes.RECT2I, model);
+						this.encode_Rect2i(value, model);
 					} else if (value instanceof Rect2) {
 						this.encode_UInt32(GDScriptTypes.RECT2, model);
 						this.encode_Rect2(value, model);
+					} else if (value instanceof Vector3i) {
+						this.encode_UInt32(GDScriptTypes.VECTOR3I, model);
+						this.encode_Vector3i(value, model);
 					} else if (value instanceof Vector3) {
 						this.encode_UInt32(GDScriptTypes.VECTOR3, model);
 						this.encode_Vector3(value, model);
+					} else if (value instanceof Vector4i) {
+						this.encode_UInt32(GDScriptTypes.VECTOR4I, model);
+						this.encode_Vector4i(value, model);
+					} else if (value instanceof Vector4) {
+						this.encode_UInt32(GDScriptTypes.VECTOR4, model);
+						this.encode_Vector4(value, model);
 					} else if (value instanceof Transform2D) {
 						this.encode_UInt32(GDScriptTypes.TRANSFORM2D, model);
 						this.encode_Transform2D(value, model);
+					} else if (value instanceof StringName) {
+						this.encode_UInt32(GDScriptTypes.STRING_NAME, model);
+						this.encode_StringName(value, model);
 					} else if (value instanceof Plane) {
 						this.encode_UInt32(GDScriptTypes.PLANE, model);
 						this.encode_Plane(value, model);
 					} else if (value instanceof Quat) {
-						this.encode_UInt32(GDScriptTypes.QUAT, model);
+						this.encode_UInt32(GDScriptTypes.QUATERNION, model);
 						this.encode_Quat(value, model);
 					} else if (value instanceof AABB) {
 						this.encode_UInt32(GDScriptTypes.AABB, model);
@@ -105,8 +129,8 @@ export class VariantEncoder {
 						this.encode_UInt32(GDScriptTypes.BASIS, model);
 						this.encode_Basis(value, model);
 					} else if (value instanceof Transform) {
-						this.encode_UInt32(GDScriptTypes.TRANSFORM, model);
-						this.encode_Transform(value, model);
+						this.encode_UInt32(GDScriptTypes.TRANSFORM3D, model);
+						this.encode_Transform3D(value, model);
 					} else if (value instanceof Color) {
 						this.encode_UInt32(GDScriptTypes.COLOR, model);
 						this.encode_Color(value, model);
@@ -141,10 +165,10 @@ export class VariantEncoder {
 	}
 
 	private encode_Color(value: Color, model: BufferModel) {
-		this.encode_Float(value.r, model);
-		this.encode_Float(value.g, model);
-		this.encode_Float(value.b, model);
-		this.encode_Float(value.a, model);
+		this.encode_Float32(value.r, model);
+		this.encode_Float32(value.g, model);
+		this.encode_Float32(value.b, model);
+		this.encode_Float32(value.a, model);
 	}
 
 	private encode_Dictionary(dict: Map<any, any>, model: BufferModel) {
@@ -158,33 +182,38 @@ export class VariantEncoder {
 		});
 	}
 
-	private encode_Double(value: number, model: BufferModel) {
+	private encode_Float64(value: number, model: BufferModel) {
 		model.buffer.writeDoubleLE(value, model.offset);
 		model.offset += 8;
 	}
 
-	private encode_Float(value: number, model: BufferModel) {
+	private encode_Float32(value: number, model: BufferModel) {
 		model.buffer.writeFloatLE(value, model.offset);
 		model.offset += 4;
 	}
 
 	private encode_Plane(value: Plane, model: BufferModel) {
-		this.encode_Float(value.x, model);
-		this.encode_Float(value.y, model);
-		this.encode_Float(value.z, model);
-		this.encode_Float(value.d, model);
+		this.encode_Float32(value.x, model);
+		this.encode_Float32(value.y, model);
+		this.encode_Float32(value.z, model);
+		this.encode_Float32(value.d, model);
 	}
 
 	private encode_Quat(value: Quat, model: BufferModel) {
-		this.encode_Float(value.x, model);
-		this.encode_Float(value.y, model);
-		this.encode_Float(value.z, model);
-		this.encode_Float(value.w, model);
+		this.encode_Float32(value.x, model);
+		this.encode_Float32(value.y, model);
+		this.encode_Float32(value.z, model);
+		this.encode_Float32(value.w, model);
 	}
 
 	private encode_Rect2(value: Rect2, model: BufferModel) {
 		this.encode_Vector2(value.position, model);
 		this.encode_Vector2(value.size, model);
+	}
+
+	private encode_Rect2i(value: Rect2i, model: BufferModel) {
+		this.encode_Vector2i(value.position, model);
+		this.encode_Vector2i(value.size, model);
 	}
 
 	private encode_String(str: string, model: BufferModel) {
@@ -200,7 +229,7 @@ export class VariantEncoder {
 		}
 	}
 
-	private encode_Transform(value: Transform, model: BufferModel) {
+	private encode_Transform3D(value: Transform, model: BufferModel) {
 		this.encode_Basis(value.basis, model);
 		this.encode_Vector3(value.origin, model);
 	}
@@ -216,6 +245,11 @@ export class VariantEncoder {
 		model.offset += 4;
 	}
 
+	private encode_Int32(int: number, model: BufferModel) {
+		model.buffer.writeInt32LE(int, model.offset);
+		model.offset += 4;
+	}
+
 	private encode_UInt64(value: bigint, model: BufferModel) {
 		let hi = Number(value >> BigInt(32));
 		let lo = Number(value);
@@ -225,14 +259,43 @@ export class VariantEncoder {
 	}
 
 	private encode_Vector2(value: Vector2, model: BufferModel) {
-		this.encode_Float(value.x, model);
-		this.encode_Float(value.y, model);
+		this.encode_Float32(value.x, model);
+		this.encode_Float32(value.y, model);
 	}
 
 	private encode_Vector3(value: Vector3, model: BufferModel) {
-		this.encode_Float(value.x, model);
-		this.encode_Float(value.y, model);
-		this.encode_Float(value.z, model);
+		this.encode_Float32(value.x, model);
+		this.encode_Float32(value.y, model);
+		this.encode_Float32(value.z, model);
+	}
+
+	private encode_Vector4(value: Vector4, model: BufferModel) {
+		this.encode_Float32(value.x, model);
+		this.encode_Float32(value.y, model);
+		this.encode_Float32(value.z, model);
+		this.encode_Float32(value.w, model);
+	}
+
+	private encode_Vector2i(value: Vector2i, model: BufferModel) {
+		this.encode_Int32(value.x, model);
+		this.encode_Int32(value.y, model);
+	}
+
+	private encode_Vector3i(value: Vector3i, model: BufferModel) {
+		this.encode_Int32(value.x, model);
+		this.encode_Int32(value.y, model);
+		this.encode_Int32(value.z, model);
+	}
+
+	private encode_Vector4i(value: Vector4i, model: BufferModel) {
+		this.encode_Int32(value.x, model);
+		this.encode_Int32(value.y, model);
+		this.encode_Int32(value.z, model);
+		this.encode_Int32(value.w, model);
+	}
+
+	private encode_StringName(value: StringName, model: BufferModel) {
+		this.encode_String(value.value, model);
 	}
 
 	private size_Bool(): number {
@@ -312,30 +375,44 @@ export class VariantEncoder {
 			case "undefined":
 				break;
 			default:
+				// TODO: size of nodepath, rid, object, callable, signal
 				if (Array.isArray(value)) {
 					size += this.size_array(value);
 					break;
 				} else if (value instanceof Map) {
 					size += this.size_Dictionary(value);
 					break;
+				} else if (value instanceof StringName) {
+					size += this.size_String(value.value);
+					break;
 				} else {
 					switch (value["__type__"]) {
 						case "Vector2":
+						case "Vector2i":
 							size += this.size_UInt32() * 2;
 							break;
 						case "Rect2":
+						case "Rect2i":
 							size += this.size_UInt32() * 4;
 							break;
 						case "Vector3":
+						case "Vector3i":
 							size += this.size_UInt32() * 3;
+							break;
+						case "Vector4":
+						case "Vector4i":
+							size += this.size_UInt32() * 4;
 							break;
 						case "Transform2D":
 							size += this.size_UInt32() * 6;
 							break;
+						case "Projection":
+							// TODO
+							break;
 						case "Plane":
 							size += this.size_UInt32() * 4;
 							break;
-						case "Quat":
+						case "Quaternion":
 							size += this.size_UInt32() * 4;
 							break;
 						case "AABB":
@@ -344,7 +421,7 @@ export class VariantEncoder {
 						case "Basis":
 							size += this.size_UInt32() * 9;
 							break;
-						case "Transform":
+						case "Transform3D":
 							size += this.size_UInt32() * 12;
 							break;
 						case "Color":
@@ -352,6 +429,7 @@ export class VariantEncoder {
 							break;
 					}
 				}
+				break;
 		}
 
 		return size;

--- a/src/debugger/variables/variant_encoder.ts
+++ b/src/debugger/variables/variant_encoder.ts
@@ -251,11 +251,23 @@ export class VariantEncoder {
 	}
 
 	private encode_UInt64(value: bigint, model: BufferModel) {
-		let hi = Number(value >> BigInt(32));
-		let lo = Number(value);
-
-		this.encode_UInt32(lo, model);
-		this.encode_UInt32(hi, model);
+		const max = (BigInt(1) << BigInt(8)) - BigInt(1);
+		let lo = Number(value & max);
+		model.buffer[model.offset++] = lo;
+		lo = lo >> 8;
+		model.buffer[model.offset++] = lo;
+		lo = lo >> 8;
+		model.buffer[model.offset++] = lo;
+		lo = lo >> 8;
+		model.buffer[model.offset++] = lo;
+		let hi = Number(value >> BigInt(32) & max);
+		model.buffer[model.offset++] = hi;
+		hi = hi >> 8;
+		model.buffer[model.offset++] = hi;
+		hi = hi >> 8;
+		model.buffer[model.offset++] = hi;
+		hi = hi >> 8;
+		model.buffer[model.offset++] = hi;
 	}
 
 	private encode_Vector2(value: Vector2, model: BufferModel) {

--- a/src/debugger/variables/variants.ts
+++ b/src/debugger/variables/variants.ts
@@ -356,7 +356,28 @@ export class Rect2i extends Rect2 {
 	}
 }
 
-export class Transform implements GDObject {
+export class Projection implements GDObject {
+	constructor(public x: Vector4, public y: Vector4, public z: Vector4, public w: Vector4) {}
+
+	public stringify_value(): string {
+		return `(${this.x.stringify_value()}, ${this.y.stringify_value()}, ${this.z.stringify_value()}, ${this.w.stringify_value()})`;
+	}
+
+	public sub_values(): GodotVariable[] {
+		return [
+			{ name: "x", value: this.x },
+			{ name: "y", value: this.y },
+			{ name: "z", value: this.z },
+			{ name: "w", value: this.w },
+		];
+	}
+
+	public type_name(): string {
+		return "Projection";
+	}
+}
+
+export class Transform3D implements GDObject {
 	constructor(public basis: Basis, public origin: Vector3) {}
 
 	public stringify_value(): string {

--- a/src/debugger/variables/variants.ts
+++ b/src/debugger/variables/variants.ts
@@ -278,6 +278,12 @@ export class ObjectId implements GDObject {
 	}
 }
 
+export class RID extends ObjectId {
+	public type_name(): string {
+		return "RID";
+	}
+}
+
 export class Plane implements GDObject {
 	constructor(
 		public x: number,
@@ -354,6 +360,7 @@ export class Rect2 implements GDObject {
 }
 
 export class Rect2i extends Rect2 {
+	// TODO: Truncate values in sub_values and stringify_value
 	public type_name(): string {
 		return "Rect2i";
 	}
@@ -434,5 +441,35 @@ export class StringName implements GDObject {
 
 	public type_name(): string {
 		return "StringName";
+	}
+}
+
+export class Callable implements GDObject {
+	public stringify_value(): string {
+		return "()";
+	}
+
+	public sub_values(): GodotVariable[] {
+		return [];
+	}
+
+	public type_name(): string {
+		return "Callable";
+	}
+}
+
+export class Signal implements GDObject {
+	constructor(public name: string, public oid: ObjectId) {}
+
+	public stringify_value(): string {
+		return `${this.name}() ${this.oid.stringify_value()}`;
+	}
+
+	public sub_values(): GodotVariable[] {
+		return undefined;
+	}
+
+	public type_name(): string {
+		return "Signal";
 	}
 }

--- a/src/debugger/variables/variants.ts
+++ b/src/debugger/variables/variants.ts
@@ -6,39 +6,49 @@ export enum GDScriptTypes {
 	// atomic types
 	BOOL,
 	INT,
-	REAL,
+	FLOAT,
 	STRING,
 
 	// math types
-
-	VECTOR2, // 5
+	VECTOR2,
+	VECTOR2I,
 	RECT2,
+	RECT2I,
 	VECTOR3,
+	VECTOR3I,
 	TRANSFORM2D,
+	VECTOR4,
+	VECTOR4I,
 	PLANE,
-	QUAT, // 10
+	QUATERNION,
 	AABB,
 	BASIS,
-	TRANSFORM,
+	TRANSFORM3D,
+	PROJECTION,
 
 	// misc types
 	COLOR,
-	NODE_PATH, // 15
-	_RID,
+	STRING_NAME,
+	NODE_PATH,
+	RID,
 	OBJECT,
+	CALLABLE,
+	SIGNAL,
 	DICTIONARY,
 	ARRAY,
 
-	// arrays
-	POOL_BYTE_ARRAY, // 20
-	POOL_INT_ARRAY,
-	POOL_REAL_ARRAY,
-	POOL_STRING_ARRAY,
-	POOL_VECTOR2_ARRAY,
-	POOL_VECTOR3_ARRAY, // 25
-	POOL_COLOR_ARRAY,
+	// typed arrays
+	PACKED_BYTE_ARRAY,
+	PACKED_INT32_ARRAY,
+	PACKED_INT64_ARRAY,
+	PACKED_FLOAT32_ARRAY,
+	PACKED_FLOAT64_ARRAY,
+	PACKED_STRING_ARRAY,
+	PACKED_VECTOR2_ARRAY,
+	PACKED_VECTOR3_ARRAY,
+	PACKED_COLOR_ARRAY,
 
-	VARIANT_MAX,
+	VARIANT_MAX
 }
 
 export interface BufferModel {
@@ -83,6 +93,47 @@ export class Vector3 implements GDObject {
 	}
 }
 
+export class Vector3i extends Vector3 {
+	// TODO: Truncate values in sub_values and stringify_value
+	public type_name(): string {
+		return "Vector3i";
+	}
+}
+
+export class Vector4 implements GDObject {
+	constructor(
+		public x: number = 0.0,
+		public y: number = 0.0,
+		public z: number = 0.0,
+		public w: number = 0.0
+	) {}
+
+	public stringify_value(): string {
+		return `(${clean_number(this.x)}, ${clean_number(this.y)}, ${
+			clean_number(this.z)}, ${clean_number(this.w)})`;
+	}
+
+	public sub_values(): GodotVariable[] {
+		return [
+			{ name: "x", value: this.x },
+			{ name: "y", value: this.y },
+			{ name: "z", value: this.z },
+			{ name: "w", value: this.w },
+		];
+	}
+
+	public type_name(): string {
+		return "Vector4";
+	}
+}
+
+export class Vector4i extends Vector4 {
+	// TODO: Truncate values in sub_values and stringify_value
+	public type_name(): string {
+		return "Vector4i";
+	}
+}
+
 export class Vector2 implements GDObject {
 	constructor(public x: number = 0.0, public y: number = 0.0) {}
 
@@ -99,6 +150,13 @@ export class Vector2 implements GDObject {
 
 	public type_name(): string {
 		return "Vector2";
+	}
+}
+
+export class Vector2i extends Vector2 {
+	// TODO: Truncate values in sub_values and stringify_value
+	public type_name(): string {
+		return "Vector2i";
 	}
 }
 
@@ -292,6 +350,12 @@ export class Rect2 implements GDObject {
 	}
 }
 
+export class Rect2i extends Rect2 {
+	public type_name(): string {
+		return "Rect2i";
+	}
+}
+
 export class Transform implements GDObject {
 	constructor(public basis: Basis, public origin: Vector3) {}
 
@@ -328,5 +392,23 @@ export class Transform2D implements GDObject {
 
 	public type_name(): string {
 		return "Transform2D";
+	}
+}
+
+export class StringName implements GDObject {
+	constructor(public value: string) {}
+
+	public stringify_value(): string {
+		return this.value;
+	}
+
+	public sub_values(): GodotVariable[] {
+		return [
+			{ name: "value", value: this.value },
+		];
+	}
+
+	public type_name(): string {
+		return "StringName";
 	}
 }

--- a/src/debugger/variables/variants.ts
+++ b/src/debugger/variables/variants.ts
@@ -51,6 +51,9 @@ export enum GDScriptTypes {
 	VARIANT_MAX
 }
 
+export const ENCODE_FLAG_64 = 1 << 16;
+export const ENCODE_FLAG_OBJECT_AS_ID = 1 << 16;
+
 export interface BufferModel {
 	buffer: Buffer;
 	len: number;


### PR DESCRIPTION
Closes #389 

See TODO list below for missing features. Changes include:

- Add protocol to `--remote-debug` launch parameter
- Add most new variant types
- Data structures and commands were updated

**TODO:**
- Missing variant types:
  - [x] Projection
  - [x] Callable
    - [ ] Should not show the "expansion" arrow in the inspector
  - [x] RID
  - [x] Signal
- [ ] Allow configuring which Godot version to use, to keep compatibility with 3.x
  - [ ] Start out with an editor setting, but later this could be detected for the current workspace (e.g. via reading `project.godot`)
- [x] Variants need to handle `ENCODE_FLAG_64`
  - Only handled correctly for decoding. Encoding is done without this flag (bigint is the only exception).
- [x] Determine debug protocol `tcp://` or `ws://` or `wss://` depending on settings
- [x] Variables and scene tree are not showing up
  - [ ] Variables do not update and sometimes duplicate
  - [ ] Scene tree nodes can not be inspected
- [x] Can not pause execution (only breakpoints work)
- [x] Commands probably changed more, need to go through them all