### PR TITLE
Improve displaying symbols documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"vsce": "^2.6.4"
 			},
 			"engines": {
-				"vscode": "^1.33.0"
+				"vscode": "^1.68.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@types/mocha": "^9.1.0",
 				"@types/node": "^10.12.21",
 				"@types/prismjs": "^1.16.8",
-				"@types/vscode": "^1.33.0",
+				"@types/vscode": "^1.68.0",
 				"@types/ws": "^8.2.2",
 				"tslint": "^5.20.1",
 				"typescript": "^3.5.1",
@@ -85,9 +85,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.69.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
-			"integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -1888,9 +1888,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.69.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
-			"integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
 		"@types/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-			"integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+			"version": "1.69.1",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
+			"integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -1888,9 +1888,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-			"integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+			"version": "1.69.1",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
+			"integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
 			"dev": true
 		},
 		"@types/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"author": "The Godot Engine community",
 	"publisher": "geequlim",
 	"engines": {
-		"vscode": "^1.33.0"
+		"vscode": "^1.68.0"
 	},
 	"categories": [
 		"Programming Languages",

--- a/package.json
+++ b/package.json
@@ -390,7 +390,7 @@
 		"@types/mocha": "^9.1.0",
 		"@types/node": "^10.12.21",
 		"@types/prismjs": "^1.16.8",
-		"@types/vscode": "^1.33.0",
+		"@types/vscode": "^1.68.0",
 		"@types/ws": "^8.2.2",
 		"tslint": "^5.20.1",
 		"typescript": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,18 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Force the project to run with visible navigation meshes"
+				},
+				"godot_tools.native_symbol_placement": {
+					"enum": [
+						"active",
+						"beside"
+					],
+					"enumDescriptions": [
+						"Place the native symbol window in the active tabs group",
+						"Place the native symbol window beside the active tabs group"
+					],
+					"default": "beside",
+					"description": "Where to place the native symbol windows"
 				}
 			}
 		},

--- a/src/lsp/NativeDocumentManager.ts
+++ b/src/lsp/NativeDocumentManager.ts
@@ -104,7 +104,7 @@ export default class NativeDocumentManager extends EventEmitter {
 		const panel = vscode.window.createWebviewPanel(
 			"doc",
 			symbol.name,
-			vscode.ViewColumn.Nine,
+			this.get_new_native_symbol_column(),
 			{
 				enableScripts: true, // 启用JS，默认禁用
 				retainContextWhenHidden: false, // webview被隐藏时保持状态，避免被重置
@@ -114,6 +114,39 @@ export default class NativeDocumentManager extends EventEmitter {
 		panel.title = symbol.name;
 		panel.webview.html = this.make_html_content(symbol);
 		panel.webview.onDidReceiveMessage(this.on_webview_message.bind(this));
+	}
+
+	/**
+	 * Returns placement for a new native symbol window based on the extension
+	 * configuration and previously opened native symbols.
+	 */
+	private get_new_native_symbol_column(): vscode.ViewColumn {
+		const config_placement = get_configuration("native_symbol_placement", "beside");
+
+		if (config_placement == "active") {
+			return vscode.ViewColumn.Active;
+		}
+
+		const tab_groups = vscode.window.tabGroups;
+		const visible_text_editors = vscode.window.visibleTextEditors;
+		const editor_columns = visible_text_editors.map(editor => editor.viewColumn);
+
+		// Assume the first non-editor column is the column where other native
+		// symbols have been opened.
+
+		const active_column = tab_groups.activeTabGroup.viewColumn;
+		const is_non_editor_column_active = !editor_columns.includes(active_column);
+		if (is_non_editor_column_active) {
+			return active_column;
+		}
+		
+		const all_columns = tab_groups.all.map(group => group.viewColumn);
+		const first_non_editor_column = all_columns.find(column => !editor_columns.includes(column));
+		if (first_non_editor_column) {
+			return first_non_editor_column;
+		} else {
+			return vscode.ViewColumn.Beside;
+		}
 	}
 
 	private on_webview_message(msg: any) {


### PR DESCRIPTION
Currently the documentation opens every new symbol in a separate web view window which quickly makes the workspace messy, if users navigate to nested symbols (open symbol docs from already opened documentation window). The PR addresses this issue in the following way:
- Opens symbol documentation window in new column or nearest non-editor column (user opens the documentation for the first time or has the documentation already open, switches to the editor and opens another symbol)
- Opens symbol documentation window in current column if it is a  non-editor column (user has the documentation already open and focused, then opens another symbol or clicks on a symbol link)
- Adds simple configuration that lets user switch to additional `active` placement option
- `active` placement always opens new documentation windows in the active tabs group