### PR TITLE
Add "Open Type Documentation" context menu option

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,7 @@
 			"editor/context": [
 				{
 					"command": "godot-tool.open_type_documentation",
+					"when": "godotTools.connectedToEditor",
 					"group": "navigation@9"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
 				"title": "Godot Tools: List native classes of godot"
 			},
 			{
-				"command": "godot-tool.open_symbol_documentation",
-				"title": "Open Symbol Documentation"
+				"command": "godot-tool.open_type_documentation",
+				"title": "Godot Tools: Open Type Documentation"
 			},
 			{
 				"command": "godot-tool.debugger.inspect_node",
@@ -392,7 +392,7 @@
 			],
 			"editor/context": [
 				{
-					"command": "godot-tool.open_symbol_documentation",
+					"command": "godot-tool.open_type_documentation",
 					"group": "navigation@9"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
 				"title": "Godot Tools: List native classes of godot"
 			},
 			{
+				"command": "godot-tool.open_symbol_documentation",
+				"title": "Open Symbol Documentation"
+			},
+			{
 				"command": "godot-tool.debugger.inspect_node",
 				"title": "Inspect Remote Node",
 				"icon": {
@@ -384,6 +388,12 @@
 				{
 					"command": "godot-tool.copy_resource_path_context",
 					"group": "1_godot"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "godot-tool.open_symbol_documentation",
+					"group": "navigation@9"
 				}
 			]
 		}

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -44,6 +44,7 @@ export class GodotTools {
 		vscode.commands.registerCommand("godot-tool.set_scene_file", this.set_scene_file.bind(this));
 		vscode.commands.registerCommand("godot-tool.copy_resource_path_context", this.copy_resource_path.bind(this));
 		vscode.commands.registerCommand("godot-tool.copy_resource_path", this.copy_resource_path.bind(this));
+		vscode.commands.registerCommand("godot-tool.open_symbol_documentation", this.open_symbol_documentation.bind(this));
 
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
@@ -99,6 +100,17 @@ export class GodotTools {
 		relative_path = 'res://' + relative_path;
 
 		vscode.env.clipboard.writeText(relative_path);
+    }
+
+    private open_symbol_documentation(uri: vscode.Uri) {
+        // get word under cursor
+        let activeEditor = vscode.window.activeTextEditor;
+        let document = activeEditor.document;
+        let curPos = activeEditor.selection.active;
+        let wordRange = document.getWordRangeAtPosition(curPos);
+        let symbolName = document.getText(wordRange);
+
+        this.client.open_documentation(symbolName);
     }
 
 	private set_scene_file(uri: vscode.Uri) {

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -46,6 +46,8 @@ export class GodotTools {
 		vscode.commands.registerCommand("godot-tool.copy_resource_path", this.copy_resource_path.bind(this));
 		vscode.commands.registerCommand("godot-tool.open_type_documentation", this.open_type_documentation.bind(this));
 
+        vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
+
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
 		this.connection_status.show();
@@ -238,6 +240,7 @@ export class GodotTools {
 				break;
 			case ClientStatus.CONNECTED:
 				this.retry = false;
+                vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', true);
 				this.connection_status.text = `$(check) Connected`;
 				this.connection_status.tooltip = `Connected to the GDScript language server.`;
 				if (!this.client.started) {
@@ -249,6 +252,7 @@ export class GodotTools {
 					this.connection_status.text = `$(sync) Connecting ` + this.reconnection_attempts;
 					this.connection_status.tooltip = `Connecting to the GDScript language server...`;
 				} else {
+                    vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
 					this.connection_status.text = `$(x) Disconnected`;
 					this.connection_status.tooltip = `Disconnected from the GDScript language server.`;
 				}

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -106,11 +106,11 @@ export class GodotTools {
 
     private open_type_documentation(uri: vscode.Uri) {
         // get word under cursor
-        let activeEditor = vscode.window.activeTextEditor;
-        let document = activeEditor.document;
-        let curPos = activeEditor.selection.active;
-        let wordRange = document.getWordRangeAtPosition(curPos);
-        let symbolName = document.getText(wordRange);
+        const activeEditor = vscode.window.activeTextEditor;
+        const document = activeEditor.document;
+        const curPos = activeEditor.selection.active;
+        const wordRange = document.getWordRangeAtPosition(curPos);
+        const symbolName = document.getText(wordRange);
 
         this.client.open_documentation(symbolName);
     }

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -46,7 +46,7 @@ export class GodotTools {
 		vscode.commands.registerCommand("godot-tool.copy_resource_path", this.copy_resource_path.bind(this));
 		vscode.commands.registerCommand("godot-tool.open_type_documentation", this.open_type_documentation.bind(this));
 
-        vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
+		vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
 
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
@@ -92,7 +92,7 @@ export class GodotTools {
 		if (!this.project_dir) {
 			return;
 		}
-        
+		
 		if (!uri) {
 			uri = vscode.window.activeTextEditor.document.uri;
 		}
@@ -102,18 +102,18 @@ export class GodotTools {
 		relative_path = 'res://' + relative_path;
 
 		vscode.env.clipboard.writeText(relative_path);
-    }
+	}
 
-    private open_type_documentation(uri: vscode.Uri) {
-        // get word under cursor
-        const activeEditor = vscode.window.activeTextEditor;
-        const document = activeEditor.document;
-        const curPos = activeEditor.selection.active;
-        const wordRange = document.getWordRangeAtPosition(curPos);
-        const symbolName = document.getText(wordRange);
+	private open_type_documentation(uri: vscode.Uri) {
+		// get word under cursor
+		const activeEditor = vscode.window.activeTextEditor;
+		const document = activeEditor.document;
+		const curPos = activeEditor.selection.active;
+		const wordRange = document.getWordRangeAtPosition(curPos);
+		const symbolName = document.getText(wordRange);
 
-        this.client.open_documentation(symbolName);
-    }
+		this.client.open_documentation(symbolName);
+	}
 
 	private set_scene_file(uri: vscode.Uri) {
 		let right_clicked_scene_path = uri.fsPath;
@@ -240,7 +240,7 @@ export class GodotTools {
 				break;
 			case ClientStatus.CONNECTED:
 				this.retry = false;
-                vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', true);
+				vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', true);
 				this.connection_status.text = `$(check) Connected`;
 				this.connection_status.tooltip = `Connected to the GDScript language server.`;
 				if (!this.client.started) {
@@ -252,7 +252,7 @@ export class GodotTools {
 					this.connection_status.text = `$(sync) Connecting ` + this.reconnection_attempts;
 					this.connection_status.tooltip = `Connecting to the GDScript language server...`;
 				} else {
-                    vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
+					vscode.commands.executeCommand('setContext', 'godotTools.connectedToEditor', false);
 					this.connection_status.text = `$(x) Disconnected`;
 					this.connection_status.tooltip = `Disconnected from the GDScript language server.`;
 				}

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -44,7 +44,7 @@ export class GodotTools {
 		vscode.commands.registerCommand("godot-tool.set_scene_file", this.set_scene_file.bind(this));
 		vscode.commands.registerCommand("godot-tool.copy_resource_path_context", this.copy_resource_path.bind(this));
 		vscode.commands.registerCommand("godot-tool.copy_resource_path", this.copy_resource_path.bind(this));
-		vscode.commands.registerCommand("godot-tool.open_symbol_documentation", this.open_symbol_documentation.bind(this));
+		vscode.commands.registerCommand("godot-tool.open_type_documentation", this.open_type_documentation.bind(this));
 
 		this.connection_status.text = "$(sync) Initializing";
 		this.connection_status.command = "godot-tool.check_status";
@@ -102,7 +102,7 @@ export class GodotTools {
 		vscode.env.clipboard.writeText(relative_path);
     }
 
-    private open_symbol_documentation(uri: vscode.Uri) {
+    private open_type_documentation(uri: vscode.Uri) {
         // get word under cursor
         let activeEditor = vscode.window.activeTextEditor;
         let document = activeEditor.document;

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -42,9 +42,9 @@ export default class GDScriptLanguageClient extends LanguageClient {
 		}
 	}
 
-    public open_documentation(symbolName: string) {
-        this.native_doc_manager.request_documentation(symbolName);
-    }
+	public open_documentation(symbolName: string) {
+		this.native_doc_manager.request_documentation(symbolName);
+	}
 
 	constructor(context: vscode.ExtensionContext) {
 		super(

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -42,6 +42,10 @@ export default class GDScriptLanguageClient extends LanguageClient {
 		}
 	}
 
+    public open_documentation(symbolName: string) {
+        this.native_doc_manager.request_documentation(symbolName);
+    }
+
 	constructor(context: vscode.ExtensionContext) {
 		super(
 			`GDScriptLanguageClient`,

--- a/src/lsp/NativeDocumentManager.ts
+++ b/src/lsp/NativeDocumentManager.ts
@@ -59,14 +59,14 @@ export default class NativeDocumentManager extends EventEmitter {
 		);
 	}
 
-    public request_documentation(symbolName: string) {
-        if (symbolName in this.native_classes) {
-            this.inspect_native_symbol({
-                native_class: symbolName,
-                symbol_name: symbolName,
-            });
-        }
-    }
+	public request_documentation(symbolName: string) {
+		if (symbolName in this.native_classes) {
+			this.inspect_native_symbol({
+				native_class: symbolName,
+				symbol_name: symbolName,
+			});
+		}
+	}
 
 	private async list_native_classes() {
 		let classname = await vscode.window.showQuickPick(

--- a/src/lsp/NativeDocumentManager.ts
+++ b/src/lsp/NativeDocumentManager.ts
@@ -59,6 +59,15 @@ export default class NativeDocumentManager extends EventEmitter {
 		);
 	}
 
+    public request_documentation(symbolName: string) {
+        if (symbolName in this.native_classes) {
+            this.inspect_native_symbol({
+                native_class: symbolName,
+                symbol_name: symbolName,
+            });
+        }
+    }
+
 	private async list_native_classes() {
 		let classname = await vscode.window.showQuickPick(
 			Object.keys(this.native_classes).sort(),


### PR DESCRIPTION
This adds an editor context menu option to open the symbol docs for the selected word, or the word under the cursor.

Open questions:
- [x] is `Open Symbol Documentation` the right name?
- [x] is this the correct location in the context menu?

https://user-images.githubusercontent.com/18042232/184232546-99a089d5-ca62-4ece-a291-b4c87293a4bf.mp4

Special thanks to @tomwyr, since this builds directly on his PR that fixes the doc viewer behavior.