### PR TITLE
Fix incorrect highlighting in dictionary literals

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -740,44 +740,7 @@
                 }
             ]
         },
-        "annotated-parameter2": {
-            "begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (:) \\s* ([[:alpha:]_]\\w*)? \\s* (=)? \\s* ([[:alpha:].0-9\\'\\\"_]*)?\n",
-            "end": "(,)|(?=\\))",
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.parameter.function.language.gdscript"
-                },
-                "2": {
-                    "name": "punctuation.separator.annotation.gdscript"
-                },
-                "3": {
-                    "patterns": [
-                        {
-                            "include": "#builtin_classes"
-                        },
-                        {
-                            "include": "#pascal_case_class"
-                        }
-                    ]
-                },
-                "4": {
-                    "name": "keyword.operator.assignment.gdscript"
-                },
-                "5": {
-                    "patterns": [
-                        {
-                            "include": "#base_expression"
-                        }
-                    ]
-                }
-            },
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.separator.parameters.gdscript"
-                }
-            }
-        },
-        "line-continuation": {
+        "line_continuation": {
             "patterns": [
                 {
                     "match": "(\\\\)\\s*(\\S.*$\\n?)",

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -48,16 +48,10 @@
             "include": "#self"
         },
         {
-            "include": "#const_def"
-        },
-        {
             "include": "#class_definition"
         },
         {
-            "include": "#var_def"
-        },
-        {
-            "include": "#type_hint"
+            "include": "#variable_definition"
         },
         {
             "include": "#class_name"
@@ -318,7 +312,7 @@
             "name": "keyword.control.gdscript"
         },
         "keywords": {
-            "match": "\\b(?i:class|class_name|extends|is|onready|tool|static|export|setget|const|as|void|enum|preload|assert|breakpoint|rpc|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|trait|namespace)\\b",
+            "match": "\\b(?i:class|class_name|extends|is|onready|tool|static|export|as|void|enum|preload|assert|breakpoint|rpc|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|trait|namespace)\\b",
             "name": "keyword.language.gdscript"
         },
         "letter": {
@@ -349,24 +343,51 @@
                 }
             ]
         },
-        "const_def": {
-            "match": "\\b(?i:(const))\\s+([a-zA-Z_][a-zA-Z_0-9]*)",
-            "captures": {
-                "1": {
-                    "name": "storage.type.const.gdscript"
-                },
-                "2": {
-                    "name": "constant.language.gdscript"
-                }
-            }
-        },
-        "var_def": {
-            "match": "\\b(?i:(var))\\s+(?=[a-zA-Z_][a-zA-Z_0-9]*)",
-            "captures": {
+        "variable_definition": {
+            "begin": "\\b(?:(var)|(const))",
+            "end": "$",
+            "beginCaptures": {
                 "1": {
                     "name": "storage.type.var.gdscript"
+                },
+                "2": {
+                    "name": "storage.type.const.gdscript"
                 }
-            }
+            },
+            "patterns": [
+                {
+                    "match": "(:)\\s*([\\w]*)?",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.separator.annotation.gdscript"
+                        },
+                        "2": {
+                            "name": "entity.name.type.class.gdscript"
+                        }
+                    }
+                },
+                {
+                    "match": "=(?!=)",
+                    "name": "keyword.operator.assignment.gdscript"
+                },
+                {
+                    "match": "(setget)\\s+([\\w]*)(?:[,]\\s*([\\w]*))?",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.const.gdscript"
+                        },
+                        "2": {
+                            "name": "entity.name.function.gdscript"
+                        },
+                        "3": {
+                            "name": "entity.name.function.gdscript"
+                        }
+                    }
+                },
+                {
+                    "include": "#base_expression"
+                }
+            ]
         },
         "getter_setter_godot4": {
             "patterns": [
@@ -406,14 +427,6 @@
                     ]
                 }
             ]
-        },
-        "type_hint": {
-            "match": "\\:\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?=[=\\n]|setget)",
-            "captures": {
-                "1": {
-                    "name": "entity.name.type.class.gdscript"
-                }
-            }
         },
         "class_definition": {
             "captures": {
@@ -489,8 +502,8 @@
             ]
         },
         "builtin_get_node_shorthand_quoted": {
-            "begin": "(\\$)([\\\"\\'])",
-            "end": "([\\\"\\'])",
+            "begin": "(\\$)([\"'])",
+            "end": "([\"'])|$",
             "name": "support.function.builtin.shorthand.gdscript",
             "beginCaptures": {
                 "1": {

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -548,7 +548,7 @@
             }
         },
         "builtin_classes": {
-            "match": "(?<![^.]\\.|:)\\b(OS|Vector2|Vector2i|Vector3|Vector3i|Color|Rect2|Rect2i|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|Transform3D|AABB|String|Color|NodePath|Object|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray|bool|int|float|StringName|Quaternion|PackedByteArray|PackedInt32Array|PackedInt64Array|PackedFloat32Array|PackedFloat64Array|PackedStringArray|PackedVector2Array|PackedVector2iArray|PackedVector3Array|PackedVector3iArray|PackedColorArray|super)\\b",
+            "match": "(?<![^.]\\.|:)\\b(OS|GDScript|Vector2|Vector2i|Vector3|Vector3i|Color|Rect2|Rect2i|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|Transform3D|AABB|String|Color|NodePath|Object|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray|bool|int|float|StringName|Quaternion|PackedByteArray|PackedInt32Array|PackedInt64Array|PackedFloat32Array|PackedFloat64Array|PackedStringArray|PackedVector2Array|PackedVector2iArray|PackedVector3Array|PackedVector3iArray|PackedColorArray|super)\\b",
             "name": "support.class.library.gdscript"
         },
         "const_vars": {

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -66,9 +66,6 @@
             "include": "#builtin_func"
         },
         {
-            "include": "#node_path"
-        },
-        {
             "include": "#builtin_get_node_shorthand"
         },
         {

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -624,13 +624,18 @@
         "function_declaration": {
             "name": "meta.function.gdscript",
             "begin": "(?x) \\s*\n (func) \\s+\n ([a-zA-Z_][a-zA-Z_0-9]*) \\s*\n (?=\\()",
-            "end": "(:|(?=[#'\"\\n]))",
+            "end": "((:)|(?=[#'\"\\n]))",
             "beginCaptures": {
                 "1": {
                     "name": "storage.type.function.gdscript"
                 },
                 "2": {
                     "name": "entity.name.function.gdscript"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.function.begin.gdscript"
                 }
             },
             "patterns": [

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -51,7 +51,7 @@
             "include": "#const_def"
         },
         {
-            "include": "#class_def"
+            "include": "#class_definition"
         },
         {
             "include": "#var_def"
@@ -87,22 +87,22 @@
             "include": "#class_enum"
         },
         {
-            "include": "#signal-declaration-bare"
+            "include": "#signal_declaration_bare"
         },
         {
-            "include": "#signal-declaration"
+            "include": "#signal_declaration"
         },
         {
-            "include": "#function-declaration"
+            "include": "#function_declaration"
         },
         {
             "include": "#function_keyword"
         },
         {
-            "include": "#any-method"
+            "include": "#any_method"
         },
         {
-            "include": "#any-property"
+            "include": "#any_property"
         },
         {
             "include": "#extends"
@@ -254,7 +254,7 @@
                     "include": "#control_flow"
                 },
                 {
-                    "include": "#function-call"
+                    "include": "#function_call"
                 },
                 {
                     "include": "#comment"
@@ -281,7 +281,7 @@
                     "include": "#pascal_case_class"
                 },
                 {
-                    "include": "#line-continuation"
+                    "include": "#line_continuation"
                 }
             ]
         },
@@ -392,7 +392,7 @@
                             "include": "#parameters"
                         },
                         {
-                            "include": "#line-continuation"
+                            "include": "#line_continuation"
                         },
                         {
                             "match": "\\s*(\\-\\>)\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\s*\\:",
@@ -415,7 +415,7 @@
                 }
             }
         },
-        "class_def": {
+        "class_definition": {
             "captures": {
                 "1": {
                     "name": "entity.name.type.class.gdscript"
@@ -559,7 +559,7 @@
             "match": "\\b([A-Z][a-z_0-9]*([A-Z]?[a-z_0-9]+)*[A-Z]?)\\b",
             "name": "support.class.library.gdscript"
         },
-        "signal-declaration-bare": {
+        "signal_declaration_bare": {
             "match": "(?x) \\s*\n (signal) \\s+\n ([a-zA-Z_][a-zA-Z_0-9]*)(?=[\\n\\s])",
             "captures": {
                 "1": {
@@ -570,7 +570,7 @@
                 }
             }
         },
-        "signal-declaration": {
+        "signal_declaration": {
             "name": "meta.signal.gdscript",
             "begin": "(?x) \\s*\n (signal) \\s+\n ([a-zA-Z_][a-zA-Z_0-9]*) \\s*\n (?=\\()",
             "end": "((?=[#'\"\\n]))",
@@ -587,7 +587,7 @@
                     "include": "#parameters"
                 },
                 {
-                    "include": "#line-continuation"
+                    "include": "#line_continuation"
                 },
                 {
                     "match": "\\s*(\\-\\>)\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\s*\\:",
@@ -617,11 +617,11 @@
                     "include": "#parameters"
                 },
                 {
-                    "include": "#line-continuation"
+                    "include": "#line_continuation"
                 }
             ]
         },
-        "function-declaration": {
+        "function_declaration": {
             "name": "meta.function.gdscript",
             "begin": "(?x) \\s*\n (func) \\s+\n ([a-zA-Z_][a-zA-Z_0-9]*) \\s*\n (?=\\()",
             "end": "(:|(?=[#'\"\\n]))",
@@ -638,7 +638,7 @@
                     "include": "#parameters"
                 },
                 {
-                    "include": "#line-continuation"
+                    "include": "#line_continuation"
                 },
                 {
                     "match": "\\s*(\\-\\>)\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\s*\\:",
@@ -671,7 +671,7 @@
             },
             "patterns": [
                 {
-                    "include": "#annotated-parameter"
+                    "include": "#annotated_parameter"
                 },
                 {
                     "match": "(?x)\n  ([[:alpha:]_]\\w*)\n    \\s* (?: (,) | (?=[)#\\n=]))\n",
@@ -688,11 +688,11 @@
                     "include": "#comment"
                 },
                 {
-                    "include": "#loose-default"
+                    "include": "#loose_default"
                 }
             ]
         },
-        "loose-default": {
+        "loose_default": {
             "begin": "(=)",
             "end": "(,)|(?=\\))",
             "beginCaptures": {
@@ -711,7 +711,7 @@
                 }
             ]
         },
-        "annotated-parameter": {
+        "annotated_parameter": {
             "begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (:)\n",
             "end": "(,)|(?=\\))",
             "beginCaptures": {
@@ -766,15 +766,15 @@
                 }
             ]
         },
-        "any-method": {
+        "any_method": {
             "match": "\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[(]))",
             "name": "support.function.any-method.gdscript"
         },
-        "any-property": {
+        "any_property": {
             "match": "(?<=[^.]\\.)\\b([A-Za-z_]\\w*)\\b(?![(])",
             "name": "variable.other.property.gdscript"
         },
-        "function-call": {
+        "function_call": {
             "name": "meta.function-call.gdscript",
             "comment": "Regular function call of the type \"name(args)\"",
             "begin": "(?x)\n  \\b(?=\n    ([[:alpha:]_]\\w*) \\s* (\\()\n  )\n",
@@ -786,14 +786,14 @@
             },
             "patterns": [
                 {
-                    "include": "#function-name"
+                    "include": "#function_name"
                 },
                 {
-                    "include": "#function-arguments"
+                    "include": "#function_arguments"
                 }
             ]
         },
-        "function-name": {
+        "function_name": {
             "patterns": [
                 {
                     "include": "#builtin_func"
@@ -808,7 +808,7 @@
                 }
             ]
         },
-        "function-arguments": {
+        "function_arguments": {
             "begin": "(\\()",
             "end": "(?=\\))(?!\\)\\s*\\()",
             "beginCaptures": {

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -211,6 +211,12 @@ class InnerClass:
 		key_f = Vector2(10, -10)
 	}
 
+	var dict_b = {
+		1: true,
+		4: true,
+		6: true
+	}
+
 	func _ready():
 		var list = []
 

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -3,6 +3,22 @@ class_name TestClass
 
 # ******************************************************************************
 
+var var_a = 0
+var var_b = true
+var var_c := true
+var var_d : bool = true
+var var_e :    bool = true
+var var_f:bool=true
+var var_g : string = 'foo'
+
+const const_a = 0
+const const_b = true
+const const_c := true
+const const_d : bool = true
+const const_e :    bool = true
+const const_f:bool=true
+const const_g : string = 'foo'
+
 var a
 remote var b = 10.0
 remotesync var c := 20
@@ -211,6 +227,8 @@ class InnerClass:
 		key_f = Vector2(10, -10)
 	}
 
+	dict = {}
+
 	var dict_b = {
 		1: true,
 		4: true,
@@ -220,12 +238,12 @@ class InnerClass:
 	func _ready():
 		var list = []
 
-		for i in range(10):
+		for i in range(10): # "in" should be purple (control flow)
 			list.append(i)
 
 		if true and true:
 			pass
-		elif 'foo' in list:
+		elif 'foo' in list: # "in" should be blue (boolean operator)
 			pass
 		elif false:
 			while true:


### PR DESCRIPTION
Fixes #418.

I had to completely rebuild the variable declaration rule to fix this bug.

Along the way, I removed some unused junk and standardized the names of all the rules. Some rules had `hyphenated-names` and some had `underscore_names`. Underscore names are easier for to work with in various text selection operations, so I switched all the hyphens to underscores.

![Code_uKmPXxuT2m](https://user-images.githubusercontent.com/18042232/189247250-8b1acb4e-031c-4bf9-b2c2-97ef2da119af.png)
