### PR TITLE
Clean up plugin initialization process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"await-notify": "^1.0.1",
 				"global": "^4.4.0",
-				"klaw": "^4.0.1",
 				"marked": "^4.0.11",
 				"net": "^1.0.2",
 				"terminate": "^2.5.0",
@@ -1222,14 +1221,6 @@
 			"dependencies": {
 				"node-addon-api": "^3.0.0",
 				"prebuild-install": "^6.0.0"
-			}
-		},
-		"node_modules/klaw": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-			"integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
-			"engines": {
-				"node": ">=14.14.0"
 			}
 		},
 		"node_modules/leven": {
@@ -3035,11 +3026,6 @@
 				"node-addon-api": "^3.0.0",
 				"prebuild-install": "^6.0.0"
 			}
-		},
-		"klaw": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-			"integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw=="
 		},
 		"leven": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -547,7 +547,6 @@
 	"dependencies": {
 		"await-notify": "^1.0.1",
 		"global": "^4.4.0",
-		"klaw": "^4.0.1",
 		"marked": "^4.0.11",
 		"net": "^1.0.2",
 		"terminate": "^2.5.0",

--- a/src/document_link_provider.ts
+++ b/src/document_link_provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { Uri, Position, Range, TextDocument } from "vscode";
+import { convert_resource_path_to_uri } from "./utils";
 
 export class GDDocumentLinkProvider implements vscode.DocumentLinkProvider {
 	private context: vscode.ExtensionContext;
@@ -27,7 +28,7 @@ export class GDDocumentLinkProvider implements vscode.DocumentLinkProvider {
 				const start = new Position(i, match.index);
 				const end = new Position(i, match.index + match[0].length);
 				const r = new Range(start, end);
-				const uri = await resourcePathToUri(match[0]);
+				const uri = await convert_resource_path_to_uri(match[0]);
 				if (uri instanceof Uri) {
 					links.push(new vscode.DocumentLink(r, uri));
 				}
@@ -35,13 +36,4 @@ export class GDDocumentLinkProvider implements vscode.DocumentLinkProvider {
 		}
 		return links;
 	}
-}
-
-async function resourcePathToUri(resPath: string) {
-	const files = await vscode.workspace.findFiles("**/project.godot");
-	if (!files) {
-		return resPath;
-	}
-	const project_dir = files[0].fsPath.replace("project.godot", "");
-	return Uri.joinPath(Uri.file(project_dir), resPath.substring(6));
 }

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { GDDocumentLinkProvider } from "./document_link_provider";
 import { ScenePreviewProvider } from "./scene_preview_provider";
 import GDScriptLanguageClient, { ClientStatus } from "./lsp/GDScriptLanguageClient";
-import { get_configuration, set_configuration, find_file, set_context } from "./utils";
+import { get_configuration, set_configuration, find_file, set_context, find_project_file } from "./utils";
 
 const CONFIG_CONTAINER = "godot_tools";
 const TOOL_NAME = "GodotTools";
@@ -16,12 +16,6 @@ export class GodotTools {
 	private linkProvider: GDDocumentLinkProvider = null;
 	private scenePreviewManager: ScenePreviewProvider = null;
 
-	// deprecated, need to replace with "vscode.workspace.workspaceFolders", but
-	// that's an array and not a single value
-	private workspace_dir = vscode.workspace.rootPath;
-	private project_file_name = "project.godot";
-	private project_file = "";
-	private project_dir = "";
 	private connection_status: vscode.StatusBarItem = null;
 
 	constructor(p_context: vscode.ExtensionContext) {
@@ -62,16 +56,6 @@ export class GodotTools {
 		this.connection_status.command = "godot-tool.check_status";
 		this.connection_status.show();
 
-		// TODO: maybe cache this result somehow
-		const klaw = require("klaw");
-		klaw(this.workspace_dir)
-			.on("data", item => {
-				if (path.basename(item.path) == this.project_file_name) {
-					this.project_dir = path.dirname(item.path);
-					this.project_file = item.path;
-				}
-			});
-
 		this.reconnection_attempts = 0;
 		this.client.connect_to_server();
 	}
@@ -81,15 +65,22 @@ export class GodotTools {
 	}
 
 	private open_workspace_with_editor(params = "") {
-
-		return new Promise<void>((resolve, reject) => {
+		return new Promise<void>(async (resolve, reject) => {
 			let valid = false;
-			if (this.project_dir) {
-				let cfg = this.project_file;
-				valid = (fs.existsSync(cfg) && fs.statSync(cfg).isFile());
-			}
+            let project_dir = '';
+            let project_file = '';
+            
+            if (vscode.workspace.workspaceFolders != undefined) {
+                const files = await vscode.workspace.findFiles("**/project.godot");
+                if (files) {
+                    project_file = files[0].fsPath;
+                    project_dir = path.dirname(project_file);
+                    let cfg = project_file;
+                    valid = (fs.existsSync(cfg) && fs.statSync(cfg).isFile());
+                }
+            }
 			if (valid) {
-				this.run_editor(`--path "${this.project_dir}" ${params}`).then(() => resolve()).catch(err => {
+				this.run_editor(`--path "${project_dir}" ${params}`).then(() => resolve()).catch(err => {
 					reject(err);
 				});
 			} else {
@@ -99,18 +90,20 @@ export class GodotTools {
 	}
 
 	private copy_resource_path(uri: vscode.Uri) {
-		if (!this.project_dir) {
-			return;
-		}
-		
 		if (!uri) {
 			uri = vscode.window.activeTextEditor.document.uri;
 		}
 
-		let relative_path = path.normalize(path.relative(this.project_dir, uri.fsPath));
+        const project_dir = path.dirname(find_project_file(uri.fsPath));
+        if (project_dir === null) {
+            return
+        }
+        
+		let relative_path = path.normalize(path.relative(project_dir, uri.fsPath));
 		relative_path = relative_path.split(path.sep).join(path.posix.sep);
 		relative_path = "res://" + relative_path;
 
+        logger.log(relative_path)
 		vscode.env.clipboard.writeText(relative_path);
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,25 @@ export function set_context(name: string, value: any) {
 	vscode.commands.executeCommand("setContext", name, value);
 }
 
+export function find_project_file(start: string, depth:number=20) {
+    // This function appears to be fast enough, but if speed is ever an issue,
+    // memoizing the result should be straightforward
+    const folder = path.dirname(start);
+    if (start == folder) {
+        return null;
+    }
+    const project_file = path.join(folder, "project.godot");
+
+    if (fs.existsSync(project_file)) {
+        return project_file;
+    } else {
+        if (depth === 0) { 
+            return null;
+        }
+        return find_project_file(folder, depth - 1);
+    }
+}
+
 export async function find_file(file: string): Promise<vscode.Uri|null> {
 	if (fs.existsSync(file)) {
 		return vscode.Uri.file(file);


### PR DESCRIPTION
This should be a fix for #435.

Apparently, the plugin would fail to initialize if you were starting VSCode without a workspace. I exclusively open folders as workspaces, so I never thought to test this scenario.

The failure is because the plugin was trying to find `project.godot` when it activated, and several things assumed that would never fail. I've completely removed this search from the plugin activation and every place that needs the project file/directory now just looks it up when it needs it.

This also means I can remove a dependency (klaw), which is always good.