### PR TITLE
Fix various syntax highlighting problems

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -346,7 +346,7 @@
         },
         "variable_definition": {
             "begin": "\\b(?:(var)|(const))",
-            "end": "$",
+            "end": "$|;",
             "beginCaptures": {
                 "1": {
                     "name": "storage.type.var.gdscript"

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -345,7 +345,7 @@
             ]
         },
         "variable_definition": {
-            "begin": "\\b(?:(var)|(const))",
+            "begin": "\\b(?:(var)|(const))\\s+",
             "end": "$|;",
             "beginCaptures": {
                 "1": {

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -667,6 +667,9 @@
                             "name": "entity.name.type.class.gdscript"
                         }
                     }
+                },
+                {
+                    "include": "#base_expression"
                 }
             ]
         },

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -117,8 +117,8 @@
                     "end": "(?:\\s*\\))",
                     "patterns": [
                         {
-                            "begin": "[\\\"\\']",
-                            "end": "[\\\"\\']",
+                            "begin": "[\"']",
+                            "end": "[\"']",
                             "name": "constant.character.escape"
                         },
                         {
@@ -177,8 +177,8 @@
             "end": "(?:\\))",
             "patterns": [
                 {
-                    "begin": "[\\\"\\']",
-                    "end": "[\\\"\\']",
+                    "begin": "[\"']",
+                    "end": "[\"']",
                     "name": "constant.character.escape",
                     "patterns": [
                         {
@@ -200,8 +200,8 @@
             "end": "(?:\\))",
             "patterns": [
                 {
-                    "begin": "[\\\"\\']",
-                    "end": "[\\\"\\']",
+                    "begin": "[\"']",
+                    "end": "[\"']",
                     "name": "constant.character.escape",
                     "patterns": [
                         {
@@ -504,7 +504,7 @@
         },
         "builtin_get_node_shorthand_quoted": {
             "begin": "(\\$)([\"'])",
-            "end": "([\"'])|$",
+            "end": "([\"'])",
             "name": "support.function.builtin.shorthand.gdscript",
             "beginCaptures": {
                 "1": {
@@ -525,7 +525,7 @@
                     "name": "keyword.control.flow"
                 },
                 {
-                    "match": "[^%]*",
+                    "match": "[^%^\"^']*",
                     "name": "constant.character.escape"
                 }
             ]

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -10,6 +10,7 @@ var var_d : bool = true
 var var_e :    bool = true
 var var_f:bool=true
 var var_g : string = 'foo'
+var var_h : string = "foo"
 
 const const_a = 0
 const const_b = true
@@ -18,6 +19,7 @@ const const_d : bool = true
 const const_e :    bool = true
 const const_f:bool=true
 const const_g : string = 'foo'
+const const_h : string = "foo"
 
 var a
 remote var b = 10.0
@@ -170,6 +172,19 @@ onready var node_j = $badlyNamedChild/badly_named_grandchild
 var node_path_a = NodePath("Child")
 var node_path_b = NodePath('Child/GrandChild')
 var node_path_c = NodePath('../Sibling')
+
+var node_method_result_a = get_node("Child").some_method()
+var node_method_result_b = get_node("Child/GrandChild").some_method()
+var node_method_result_c = get_node("%Child").some_method()
+var node_method_result_d = $Child.some_method()
+var node_method_result_e = $'Child'.some_method()
+var node_method_result_f = $'%Child'.some_method()
+var node_method_result_g = $Child/GrandChild.some_method()
+var node_method_result_h = $"Child/GrandChild".some_method()
+var node_method_result_i = $"%Child/GrandChild".some_method()
+var node_method_result_j = $Child.get_node('GrandChild').some_method()
+var node_method_result_k = $"Child".get_node('GrandChild').some_method()
+var node_method_result_l = $"%Child".get_node('GrandChild').some_method()
 
 # ------------------------------------------------------------------------------
 

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -118,6 +118,12 @@ func func_c(
 	):
 	pass
 
+# one line functions, please don't actually do this
+func one_line_int_fn() -> int: return 3
+func one_line_dict_fn() -> int: return {a=0, b=0.0, c='test'}
+func one_line_print() -> void: print("Uh oh")
+func one_line_fn() -> void: return
+
 # ------------------------------------------------------------------------------
 
 var q = "double quotes"

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -21,6 +21,10 @@ const const_f:bool=true
 const const_g : string = 'foo'
 const const_h : string = "foo"
 
+var pls_no_a = "don't do this"; var pls_no_b = "I don't care if it's valid";
+var pls_no_c = 0; var pls_no_d = false; var pls_no_e = seriously_why();
+var pls_no_f: bool; var pls_no_g: int; var pls_no_h: string;
+
 var a
 remote var b = 10.0
 remotesync var c := 20
@@ -228,6 +232,8 @@ func if_test():
 		pass
 	else:
 		pass
+
+	if some_bool: return
 
 # ------------------------------------------------------------------------------
 

--- a/syntaxes/examples/gdscript1.gd
+++ b/syntaxes/examples/gdscript1.gd
@@ -40,6 +40,9 @@ signal sig_c(param1, param2)
 # 		param2: Dictionary,
 # 	)
 
+var variant_a = 0
+const variant_b = 0
+
 # ------------------------------------------------------------------------------
 
 var f = 40 setget set_f


### PR DESCRIPTION
This fixes a number of minor syntax highlighting problems I've identified.

## Incorrect quote matching on $ operator

![image](https://user-images.githubusercontent.com/18042232/209418564-7def55bc-c4c0-4c81-86a7-7f247d1d0f20.png)

## Multiple statements on one line using ; (semicolon)

This one's a bit wierd:

v1.3.1:

![image](https://user-images.githubusercontent.com/18042232/209418684-80cd2bfd-0e72-40b9-b88a-fe65ebaafe33.png)

current master:

![image](https://user-images.githubusercontent.com/18042232/209418733-04b1af95-6804-4683-8f5d-ecaaae61b26d.png)

This PR:

![image](https://user-images.githubusercontent.com/18042232/209418738-7f4bb24d-9bcf-4645-94a2-4770bed1c054.png)


## Other problems

I've seen some problems with Godot 4 syntax, too, but unfortunately I wasn't smart enough to make notes on all of them. I'm going to do some work in Godot 4 this weekend, and if I see anything weird I'll try to get it added to this PR.

- [ ] set/get: I remember seeing something wrong with these, maybe related to line-continuations?
- [ ] ???
