### PR TITLE
Fix errors left after cleaning up plugin initialization process

### DIFF
--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -208,7 +208,6 @@ export class GodotTools {
 			};
 
 			let editorPath = get_configuration("editor_path", "");
-			editorPath = editorPath.replace("${workspaceRoot}", this.workspace_dir);
 			if (!fs.existsSync(editorPath) || !fs.statSync(editorPath).isFile()) {
 				vscode.window.showOpenDialog({
 					openLabel: "Run",

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -103,7 +103,6 @@ export class GodotTools {
 		relative_path = relative_path.split(path.sep).join(path.posix.sep);
 		relative_path = "res://" + relative_path;
 
-        logger.log(relative_path)
 		vscode.env.clipboard.writeText(relative_path);
 	}
 


### PR DESCRIPTION
#439 apparently had a couple accidents, a leftover log statement and a reference to a removed class variable, `workspace_dir`.

The reference to `workspace_dir` affects the code path for launching the Godot editor from VSCode, and that feature still works even when I remove the entire line. I didn't write this feature, and I don't see a purpose for this line in the first place.