### PR TITLE
Change default LSP Port for Godot 4's one

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 				},
 				"godotTools.lsp.serverPort": {
 					"type": "number",
-					"default": 6008,
+					"default": 6005,
 					"description": "The server port of the GDScript language server"
 				},
 				"godotTools.editorPath": {

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -230,8 +230,8 @@ export class GodotTools {
 	}
 
 	private check_client_status() {
-		let host = get_configuration("lsp.serverPort", "localhost");
-		let port = get_configuration("lsp.serverHost", 6008);
+		let host = get_configuration("lsp.serverHost", "localhost");
+		let port = get_configuration("lsp.serverPort", 6005);
 		switch (this.client.status) {
 			case ClientStatus.PENDING:
 				vscode.window.showInformationMessage(`Connecting to the GDScript language server at ${host}:${port}`);
@@ -247,7 +247,7 @@ export class GodotTools {
 
 	private on_client_status_changed(status: ClientStatus) {
 		let host = get_configuration("lsp.serverHost", "localhost");
-		let port = get_configuration("lsp.serverPort", 6008);
+		let port = get_configuration("lsp.serverPort", 6005);
 		switch (status) {
 			case ClientStatus.PENDING:
 				this.connection_status.text = `$(sync) Connecting`;
@@ -302,7 +302,7 @@ export class GodotTools {
 		this.connection_status.tooltip = `Disconnected from the GDScript language server.`;
 
 		let host = get_configuration("lsp.serverHost", "localhost");
-		let port = get_configuration("lsp.serverPort", 6008);
+		let port = get_configuration("lsp.serverPort", 6005);
 		let message = `Couldn't connect to the GDScript language server at ${host}:${port}. Is the Godot editor running?`;
 		vscode.window.showErrorMessage(message, "Open Godot Editor", "Retry", "Ignore").then(item => {
 			if (item == "Retry") {

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -79,7 +79,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 	connect_to_server() {
 		this.status = ClientStatus.PENDING;
 		let host = get_configuration("lsp.serverHost", "127.0.0.1");
-		let port = get_configuration("lsp.serverPort", 6008);
+		let port = get_configuration("lsp.serverPort", 6005);
 		this.io.connect_to_language_server(host, port);
 	}
 


### PR DESCRIPTION
Changes the default LSP Port from 6008 (Used in Godot 3) for 6005 (Used in Godot 4). This change was made in https://github.com/godotengine/godot/commit/de7873c2d87c3ee8af8c27e35f49767fcc384e75 .

Also fixes a potential bug in the `check_client_status()` function. It was wrongly getting the `serverProperty `from the `serverPort `configuration and viceversa.