### PR TITLE
add warning and instructions to README.md for godot 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 A complete set of tools to code games with
 [Godot Engine](http://www.godotengine.org/) in Visual Studio Code.
 
+> **Warning**
+> 
+> This plugin requires manual configuration to work with Godot 4!
+> See the [`gdscript_lsp_server_port` setting](#gdscript_lsp_server_port)
+> item under the Configuration section below.
+
 **IMPORTANT NOTE:** Versions 1.0.0 and later of this extension only support
 Godot 3.2 or later.
 
@@ -47,7 +53,7 @@ The extension adds a few entries to the VS Code Command Palette under "Godot Too
 - Run the workspace as a Godot project
 - List Godot's native classes
 
-## Settings
+## Configuration
 
 ### Godot
 
@@ -63,11 +69,22 @@ for Godot by following these steps:
 
 ### VS Code
 
+#### Settings
+
 You can use the following settings to configure Godot Tools:
 
-- `editor_path` - The absolute path to the Godot editor executable. _Under Mac OS, this is the executable inside of Godot.app._
-- `gdscript_lsp_server_port` - The WebSocket server port of the GDScript language server.
-- `checkStatus` - Check the GDScript language server connection status.
+##### `editor_path`
+
+The absolute path to the Godot editor executable. _Under Mac OS, this is the executable inside of Godot.app._
+
+##### `gdscript_lsp_server_port`
+
+The WebSocket server port of the GDScript language server.
+
+For Godot 3, the default value of `6008` should work out of the box.
+
+**For Godot 4, this value must be changed to `6005` for this extension to connect to the language server.**
+See [this tracking issue](https://github.com/godotengine/godot-vscode-plugin/issues/473) for more information.
 
 #### GDScript Debugger
 


### PR DESCRIPTION
This PR attempts to alleviate some of the confusion caused by https://github.com/godotengine/godot-vscode-plugin/issues/473.

It adds a warning at top of README.md about the manual configuration required to use this extension with Godot 4, as well as instructions in the VS Code configuration section about what port to use.

I've lightly reformated that section to better allow for multi-line setting descriptions and anchor linking (so that the warning at the top of the readme can directly link to the relevant section).

Additionally, I removed the `checkStatus` setting documentation, since as far as I can tell it no longer exists. There seem to be a number of new, undocumented extension settings, but maybe those could be added in a further PR.