### PR TITLE
Default language server port doesn't match with Godot 4 (#473) fix + Godot 3 back-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,6 @@ When developing for the extension, you can open this project in Visual Studio Co
 ### Why does it fail to connect to the language server?
 
 - Godot 3.2 or later is required.
-- For Godot 4, the [`gdscript_lsp_server_port` setting](#gdscript_lsp_server_port)
-  must be changed to `6005` to match the Godot editor's new default
-  language server port number.
 - Make sure to open the project in the Godot editor first. If you opened
   the editor after opening VS Code, you can click the **Retry** button
   in the bottom-right corner in VS Code.

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ The absolute path to the Godot editor executable. _Under Mac OS, this is the exe
 
 The WebSocket server port of the GDScript language server.
 
-For Godot 3, the default value of `6008` should work out of the box.
+For Godot 4, the default value of `6005` should work out of the box.
 
-**For Godot 4, this value must be changed to `6005` for this extension to connect to the language server.**
-See [this tracking issue](https://github.com/godotengine/godot-vscode-plugin/issues/473) for more information.
+If connecting to this port fails, then it will fall back to port `6008` for compatibility with Godot 3.
 
 #### GDScript Debugger
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 A complete set of tools to code games with
 [Godot Engine](http://www.godotengine.org/) in Visual Studio Code.
 
-> **Warning**
-> 
-> This plugin requires manual configuration to work with Godot 4!
-> See the [`gdscript_lsp_server_port` setting](#gdscript_lsp_server_port)
-> item under the Configuration section below.
-
 **IMPORTANT NOTE:** Versions 1.0.0 and later of this extension only support
 Godot 3.2 or later.
 

--- a/package.json
+++ b/package.json
@@ -181,8 +181,13 @@
 				},
 				"godotTools.lsp.serverPort": {
 					"type": "number",
-					"default": 6008,
+					"default": 6005,
 					"description": "The server port of the GDScript language server"
+				},
+				"godotTools.lsp.serverPortFallback": {
+					"type": "number",
+					"default": 6008,
+					"description": "A fallback server port for the GDScript language server, for Godot 3 compatibility"
 				},
 				"godotTools.editorPath": {
 					"type": "string",
@@ -206,7 +211,7 @@
 				},
 				"godotTools.lsp.autoReconnect.attempts": {
 					"type": "number",
-					"default": 10,
+					"default": 20,
 					"description": "How many times the client will attempt to reconnect"
 				},
 				"godotTools.forceVisibleCollisionShapes": {

--- a/src/godot-tools.ts
+++ b/src/godot-tools.ts
@@ -230,8 +230,8 @@ export class GodotTools {
 	}
 
 	private check_client_status() {
-		let host = get_configuration("lsp.serverPort", "localhost");
-		let port = get_configuration("lsp.serverHost", 6008);
+		let host = get_configuration("lsp.serverHost", "localhost");
+		let port = get_configuration("lsp.serverPort", 6008);
 		switch (this.client.status) {
 			case ClientStatus.PENDING:
 				vscode.window.showInformationMessage(`Connecting to the GDScript language server at ${host}:${port}`);

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -76,10 +76,11 @@ export default class GDScriptLanguageClient extends LanguageClient {
 		this.native_doc_manager = new NativeDocumentManager(this.io);
 	}
 
-	connect_to_server() {
+	connect_to_server(use_fallback: Boolean = false) {
 		this.status = ClientStatus.PENDING;
 		let host = get_configuration("lsp.serverHost", "127.0.0.1");
-		let port = get_configuration("lsp.serverPort", 6008);
+		let port = get_configuration("lsp.serverPort", 6005);
+		if(use_fallback) port = get_configuration("lsp.serverPortFallback", 6008);
 		this.io.connect_to_language_server(host, port);
 	}
 


### PR DESCRIPTION
I figured it would be good to update the default for Godot 4 as people seem to get caught up on it fairly frequently (#473), however there's still a lot of v3 users, so as a compromise I've added a fallback port, which it will use when it's used up half of the max connection attempts. I also doubled the number of connection attempts, so both ports get the 10 they were getting before.

By default, the main `serverPort` is the Godot 4 default, and the fallback is the Godot 3 default.

I tested this code of course, but I haven't developed much for VScode or Godot before, so please scrutinise my code as much as you like.


As an aside, I noticed that the warning message at the top of the README isn't on the VSCode marketplace? Seems like the version published there might be out of date.