### PR TITLE
Add additional launch profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,12 +4,30 @@
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
 	"version": "0.2.0",
-	"configurations": [{
+	"configurations": [
+		{
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: watch",
+			"env": {
+				"VSCODE_DEBUG_MODE": true
+			}
+		},
+		{
+			"name": "Run Extension with workspace file",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"${workspaceFolder}/workspace.code-workspace",
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [


### PR DESCRIPTION
I'm adding an additional launch profile to streamline launching the extension host using a local workspace file. I use this to rapidly switch between a Godot 3 project and a Godot 4 project with minimal menu-ing.