### PR TITLE
Improve LSP connection behavior (fixes Godot3/4 port issue)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,64 +44,89 @@ export class Logger {
 	}
 }
 
-export class Logger2 {
-	protected tag: string = "";
-	protected level: string = "";
-	protected time: boolean = false;
+export enum LOG_LEVEL {
+	SILENT,
+	ERROR,
+	WARNING,
+	INFO,
+	DEBUG,
+}
 
-	constructor(tag: string) {
-		this.tag = tag;
+const LOG_LEVEL_NAMES = [
+	"SILENT",
+	"ERROR",
+	"WARN ",
+	"INFO ",
+	"DEBUG",
+]
+
+const RESET = "\u001b[0m"
+
+const LOG_COLORS = [
+	RESET, // SILENT, normal
+	"\u001b[1;31m", // ERROR, red
+	"\u001b[1;33m", // WARNING, yellow
+	"\u001b[1;36m", // INFO, cyan
+	"\u001b[1;32m", // DEBUG, green
+]
+
+export class Logger2 {
+	private show_tag: boolean = true;
+	private show_time: boolean;
+	private show_label: boolean;
+	private show_level: boolean = false;
+
+	constructor(
+		private tag: string,
+		private level: LOG_LEVEL = LOG_LEVEL.DEBUG,
+		{ time = false, label = false }: { time?: boolean, label?: boolean } = {},
+	) {
+		this.show_time = time;
+		this.show_label = label;
 	}
 
-	log(...messages) {
-		let line = "[godotTools]";
-		if (this.time) {
-			line += `[${new Date().toISOString()}]`;
+	private log(level: LOG_LEVEL, ...messages) {
+		let prefix = "";
+		if (this.show_label) {
+			prefix += "[godotTools]";
 		}
-		if (this.level) {
-			line += `[${this.level}]`;
-			this.level = "";
+		if (this.show_time) {
+			prefix += `[${new Date().toISOString()}]`;
 		}
-		if (this.tag) {
-			line += `[${this.tag}]`;
+		if (this.show_level) {
+			prefix += "[" + LOG_COLORS[level] + LOG_LEVEL_NAMES[level] + RESET + "]";
 		}
-		if (line) {
-			line += " ";
-		}
-
-		for (let index = 0; index < messages.length; index++) {
-			line += messages[index];
-			if (index < messages.length) {
-				line += " ";
-			} else {
-				line += "\n";
-			}
+		if (this.show_tag) {
+			prefix += "[" + LOG_COLORS[level] + this.tag + RESET + "]";
 		}
 
-		console.log(line);
+		console.log(prefix, ...messages);
 	}
 
 	info(...messages) {
-		this.level = "INFO";
-		this.log(messages);
+		if (LOG_LEVEL.INFO <= this.level) {
+			this.log(LOG_LEVEL.INFO, ...messages);
+		}
 	}
 	debug(...messages) {
-		this.level = "DEBUG";
-		this.log(messages);
+		if (LOG_LEVEL.DEBUG <= this.level) {
+			this.log(LOG_LEVEL.DEBUG, ...messages);
+		}
 	}
 	warn(...messages) {
-		this.level = "WARNING";
-		this.log(messages);
+		if (LOG_LEVEL.WARNING <= this.level) {
+			this.log(LOG_LEVEL.WARNING, ...messages);
+		}
 	}
 	error(...messages) {
-		this.level = "ERROR";
-		this.log(messages);
+		if (LOG_LEVEL.ERROR <= this.level) {
+			this.log(LOG_LEVEL.ERROR, ...messages);
+		}
 	}
 }
 
-
-export function createLogger(tag) {
-	return new Logger2(tag);
+export function createLogger(tag, level: LOG_LEVEL = LOG_LEVEL.DEBUG) {
+	return new Logger2(tag, level);
 }
 
 const logger = new Logger("godot-tools", true);

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -73,7 +73,6 @@ export class ClientConnectionManager {
 		this.target = TargetLSP.EDITOR;
 		this.connectedVersion = undefined;
 
-		// TODO: why does changing lsp.headless require reloading vscode?
 		if (get_configuration("lsp.headless")) {
 			this.target = TargetLSP.HEADLESS;
 			await this.start_language_server();

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -225,7 +225,7 @@ export class ClientConnectionManager {
 				// vscode.window.showInformationMessage("Initializing LSP");
 				break;
 			case ManagerStatus.PENDING:
-				// vscode.window.showInformationMessage(`Connecting to the GDScript language server at ${lsp_target}`);
+				// vscode.window.showInformationMessage(`Connecting to the GDScript language server at ${lspTarget}`);
 				break;
 			case ManagerStatus.CONNECTED: {
 				const message = `Connected to the GDScript language server at ${lspTarget}.`;
@@ -333,9 +333,9 @@ export class ClientConnectionManager {
 	}
 
 	private retry_connect_client() {
-		const auto_retry = get_configuration("lsp.autoReconnect.enabled");
-		const max_attempts = get_configuration("lsp.autoReconnect.attempts");
-		if (auto_retry && this.reconnectionAttempts <= max_attempts - 1) {
+		const autoRetry = get_configuration("lsp.autoReconnect.enabled");
+		const maxAttempts = get_configuration("lsp.autoReconnect.attempts");
+		if (autoRetry && this.reconnectionAttempts <= maxAttempts - 1) {
 			this.reconnectionAttempts++;
 			this.client.connect_to_server(this.target);
 			this.retry = true;
@@ -346,8 +346,8 @@ export class ClientConnectionManager {
 		this.status = ManagerStatus.DISCONNECTED;
 		this.update_status_widget();
 
-		const lsp_target = this.get_lsp_connection_string();
-		let message = `Couldn't connect to the GDScript language server at ${lsp_target}. Is the Godot editor or language server running?`;
+		const lspTarget = this.get_lsp_connection_string();
+		let message = `Couldn't connect to the GDScript language server at ${lspTarget}. Is the Godot editor or language server running?`;
 		vscode.window.showErrorMessage(message, "Retry", "Ignore").then(item => {
 			if (item == "Retry") {
 				this.connect_to_language_server();

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -120,7 +120,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 	}
 
 	private on_send_message(message: RequestMessage) {
-		log.debug("tx: " + JSON.stringify(message));
+		log.debug("tx:", message);
 
 		this.sentMessages.set(message.id, message.method);
 
@@ -131,7 +131,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 
 	private on_message(message: ResponseMessage) {
 		const msgString = JSON.stringify(message);
-		log.debug("rx: " + msgString);
+		log.debug("rx:", message);
 
 		// This is a dirty hack to fix the language server sending us
 		// invalid file URIs

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -4,7 +4,7 @@ import { LanguageClient, RequestMessage, ResponseMessage, integer } from "vscode
 import { createLogger } from "../logger";
 import { get_configuration, set_context } from "../utils";
 import { Message, MessageIO, MessageIOReader, MessageIOWriter, TCPMessageIO, WebSocketMessageIO } from "./MessageIO";
-import NativeDocumentManager from './NativeDocumentManager';
+import { NativeDocumentManager } from './NativeDocumentManager';
 
 const log = createLogger("lsp.client");
 
@@ -22,7 +22,6 @@ export enum TargetLSP {
 const CUSTOM_MESSAGE = "gdscrip_client/";
 
 export default class GDScriptLanguageClient extends LanguageClient {
-
 	public readonly io: MessageIO = (get_configuration("lsp.serverProtocol") == "ws") ? new WebSocketMessageIO() : new TCPMessageIO();
 
 	private context: vscode.ExtensionContext;

--- a/src/lsp/NativeDocumentManager.ts
+++ b/src/lsp/NativeDocumentManager.ts
@@ -24,7 +24,7 @@ const enum WebViewMessageType {
 	INSPECT_NATIVE_SYMBOL = "INSPECT_NATIVE_SYMBOL",
 }
 
-export default class NativeDocumentManager extends EventEmitter {
+export class NativeDocumentManager extends EventEmitter {
 	private io: MessageIO = null;
 	private native_classes: { [key: string]: GodotNativeClassInfo } = {};
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,10 +5,8 @@ import { AddressInfo, createServer } from "net";
 
 const EXTENSION_PREFIX = "godotTools";
 
-const config = vscode.workspace.getConfiguration(EXTENSION_PREFIX);
-
 export function get_configuration(name: string, default_value?: any) {
-	let config_value = config.get(name, null);
+	let config_value = vscode.workspace.getConfiguration(EXTENSION_PREFIX).get(name, null);
 	if (default_value && config_value === null) {
 		return default_value;
 	}
@@ -16,7 +14,7 @@ export function get_configuration(name: string, default_value?: any) {
 }
 
 export function set_configuration(name: string, value: any) {
-	return config.update(name, value);
+	return vscode.workspace.getConfiguration(EXTENSION_PREFIX).update(name, value);
 }
 
 export function is_debug_mode(): boolean {


### PR DESCRIPTION
This PR internally splits the LSP client connection behavior based on backend 'target". The two possible targets are `HEADLESS` and `EDITOR`

When attempting to connect to an `EDITOR` LSP, if the value of `godotTools.lsp.serverPort` is either `6005` or `6008`, the client will try both ports in succession on each attempt. 

The end result is that with default Godot EditorSettings and default extension settings, the language server should Just Work:tm:, no matter what version of Godot is being used.

I'm considering renaming `godotTools.lsp.serverPort` and `godotTools.lsp.serverHost`, to soft-reset users to the ideal default values.