### PR TITLE
Fix Headless LSP not starting

### DIFF
--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -162,12 +162,12 @@ export class ClientConnectionManager {
 		});
 
 		// const lspStderr = createLogger("lsp.stderr");
-		// lspProcess.stderr.on('data', (data) => {
-		// 	const out = data.toString().trim();
-		// 	if (out) {
-		// 		lspStderr.debug(out);
-		// 	}
-		// });
+		lspProcess.stderr.on('data', (data) => {
+			// const out = data.toString().trim();
+			// if (out) {
+			// 	lspStderr.debug(out);
+			// }
+		});
 
 		lspProcess.on('close', (code) => {
 			log.info(`LSP process exited with code ${code}`);


### PR DESCRIPTION
Fixes #512

The Headless LSP child process had no stderr handler due to developer laziness, and in some situations this causes the process to stop responding to events.

I still don't want to see stderr in the output, but providing an empty lambda handler should hopefully prevent the process from hanging.