### PR TITLE
Syntax highlighting changes

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -94,6 +94,9 @@
             "include": "#any_method"
         },
         {
+            "include": "#any_variable"
+        },
+        {
             "include": "#any_property"
         },
         {
@@ -375,7 +378,7 @@
             ]
         },
         "variable_definition": {
-            "begin": "\\b(?:(var)|(const))\\s+",
+            "begin": "\\b(?:(var)|(const))\\s+([a-zA-Z_]\\w*)\\s*",
             "end": "$|;",
             "beginCaptures": {
                 "1": {
@@ -383,6 +386,9 @@
                 },
                 "2": {
                     "name": "storage.type.const.gdscript"
+                },
+                "3": {
+                    "name": "variable.other.gdscript"
                 }
             },
             "patterns": [
@@ -417,6 +423,18 @@
                 },
                 {
                     "include": "#base_expression"
+                },
+                {
+                    "include": "#letter"
+                },
+                {
+                    "include": "#any_variable"
+                },
+                {
+                    "include": "#any_property"
+                },
+                {
+                    "include": "#keywords"
                 }
             ]
         },
@@ -611,7 +629,7 @@
             ]
         },
         "annotations": {
-            "match": "(@)(export|export_color_no_alpha|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|icon|onready|rpc|tool|warning_ignore)\\b",
+            "match": "(@)(export|export_color_no_alpha|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|icon|onready|rpc|tool|warning_ignore|abstract)\\b",
             "captures": {
                 "1": {
                     "name": "entity.name.function.decorator.gdscript"
@@ -623,7 +641,7 @@
         },
         "builtin_classes": {
             "match": "(?<![^.]\\.|:)\\b(OS|GDScript|Vector2|Vector2i|Vector3|Vector3i|Color|Rect2|Rect2i|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|Transform3D|AABB|String|Color|NodePath|Object|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray|bool|int|float|StringName|Quaternion|PackedByteArray|PackedInt32Array|PackedInt64Array|PackedFloat32Array|PackedFloat64Array|PackedStringArray|PackedVector2Array|PackedVector2iArray|PackedVector3Array|PackedVector3iArray|PackedColorArray|super)\\b",
-            "name": "support.class.library.gdscript"
+            "name": "entity.name.type.class.builtin.gdscript"
         },
         "const_vars": {
             "match": "\\b([A-Z_][A-Z_0-9]*)\\b",
@@ -631,7 +649,7 @@
         },
         "pascal_case_class": {
             "match": "\\b([A-Z][a-z_0-9]*([A-Z]?[a-z_0-9]+)*[A-Z]?)\\b",
-            "name": "support.class.library.gdscript"
+            "name": "entity.name.type.class.gdscript"
         },
         "signal_declaration_bare": {
             "match": "(?x) \\s*\n (signal) \\s+\n ([a-zA-Z_]\\w*)(?=[\\n\\s])",
@@ -720,9 +738,11 @@
                     "include": "#line_continuation"
                 },
                 {
-                    "match": "\\s*(\\-\\>)\\s*([a-zA-Z_]\\w*)\\s*\\:",
+                    "match": "\\s*(?:\\-\\>)\\s*(void\\w*)|([a-zA-Z_]\\w*)\\s*\\:",
                     "captures": {
-                        "1": {},
+                        "1": {
+                            "name": "keyword.language.void.gdscript"
+                        },
                         "2": {
                             "name": "entity.name.type.class.gdscript"
                         }
@@ -852,8 +872,12 @@
             "match": "\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[(]))",
             "name": "support.function.any-method.gdscript"
         },
+        "any_variable": {
+            "match": "\\b(?<![@\\$#%])([A-Za-z_]\\w*)\\b(?![(])",
+            "name": "variable.other.gdscript"
+        },
         "any_property": {
-            "match": "(?<=[^.]\\.)\\b([A-Za-z_]\\w*)\\b(?![(])",
+            "match": "\\b\\.\\s*(?<![@\\$#%])([A-Za-z_]\\w*)\\b(?![(])",
             "name": "variable.other.property.gdscript"
         },
         "function_call": {
@@ -932,6 +956,18 @@
                             "name": "punctuation.definition.arguments.begin.gdscript"
                         }
                     }
+                },
+                {
+                    "include": "#letter"
+                },
+                {
+                    "include": "#any_variable"
+                },
+                {
+                    "include": "#any_property"
+                },
+                {
+                    "include": "#keywords"
                 }
             ]
         }


### PR DESCRIPTION
* Adds the upcoming `@abstract` annotation https://github.com/godotengine/godot/pull/82987 (4.3) to the list of annotations in the gdscript textmate grammar. ~~will move to a new PR~~ nvm
* Complete syntax highlighting for properties. Class properties used to be unhighlighted (the only properties highlighted were `.` properties) and are now highlighted properly as `variable.other.property.gdscript`
* Treat `void` as a `keyword` instead of a `class`. See https://github.com/godotengine/godot/blob/a574c0296b38d5f786f249b12e6251e562c528cc/modules/gdscript/gdscript_tokenizer.h#L130C4-L130C8 (gdscript considers `void` to be a keyword, similar to C-style languages)

NOTE: This is my first time working with regular expressions, so please let me know if I've made a mistake with my added regular expressions!

Before:
![image](https://github.com/godotengine/godot-vscode-plugin/assets/56272643/fbf637d8-1b6c-4607-82b7-4203f2c5b152)

After:
![image](https://github.com/godotengine/godot-vscode-plugin/assets/56272643/3815caca-7ff1-42d8-8a50-f23cb3884c27)

