### PR TITLE
Add GDScript formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,23 @@
 					"default": false,
 					"description": "Force the project to run with visible navigation meshes"
 				},
+				"godotTools.formatter": {
+					"enum": [
+						"builtin",
+						"gdformat"
+					],
+					"enumDescriptions": [
+						"GodotTools' builtin formatter",
+						"gdformat from godot-gdscript-toolkit, or a compatible formatter"
+					],
+					"default": "gdformat",
+					"description": "Which formatting tool to use"
+				},
+				"godotTools.gdformatPath": {
+					"type": "string",
+					"default": "gdformat",
+					"description": "Path to the gdformat executable"
+				},
 				"godotTools.nativeSymbolPlacement": {
 					"enum": [
 						"active",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { register_debugger } from "./debugger/debugger_context";
 import { GDDocumentLinkProvider } from "./document_link_provider";
 import { ClientConnectionManager } from "./lsp/ClientConnectionManager";
 import { ScenePreviewProvider } from "./scene_preview_provider";
+import { FormattingProvider } from "./formatter/formatter";
 import {
 	get_configuration,
 	set_configuration,
@@ -19,6 +20,7 @@ const TOOL_NAME = "GodotTools";
 let lspClientManager: ClientConnectionManager = null;
 let linkProvider: GDDocumentLinkProvider = null;
 let scenePreviewManager: ScenePreviewProvider = null;
+let formattingProvider: FormattingProvider = null;
 
 export function activate(context: vscode.ExtensionContext) {
 	attemptSettingsUpdate(context);
@@ -26,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 	lspClientManager = new ClientConnectionManager(context);
 	linkProvider = new GDDocumentLinkProvider(context);
 	scenePreviewManager = new ScenePreviewProvider();
+	formattingProvider = new FormattingProvider(context);
 
 	register_debugger(context);
 

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+import {
+	DocumentFormattingEditProvider,
+	ExtensionContext,
+	TextDocument,
+	TextEdit,
+} from "vscode";
+import { execSync } from "child_process";
+import { get_configuration } from "../utils";
+import { createLogger } from "../logger";
+
+const log = createLogger("formatter");
+
+export class FormattingProvider implements DocumentFormattingEditProvider {
+	constructor(context: ExtensionContext) {
+		context.subscriptions.push(
+			vscode.languages.registerDocumentFormattingEditProvider('gdscript', this),
+		)
+	}
+
+	async provideDocumentFormattingEdits(document: TextDocument): Promise<TextEdit[]> {
+		return new Promise((res, rej) => {
+			const formatter = get_configuration("formatter");
+
+			if (formatter === "gdformat") {
+				const formatterPath = get_configuration(`${formatter}Path`);
+				const command = `${formatterPath} ${document.uri.fsPath}`;
+				const output = execSync(`${command} `);
+				// TODO: error handling
+				res([]);
+				return;
+			}
+			if (formatter === "builtin") {
+				// Not implemented yet
+				// const command = `${formatterPath} ${document.uri.fsPath}`;
+				// const output = execSync(`${command} `);
+				// res([]);
+			}
+			rej();
+		});
+	}
+}


### PR DESCRIPTION
This PR adds a formatting provider, which currently just execs `gdformat` or a compatible formatter. 

I'm also working on a builtin formatter, which will most likely use tree-sitter, get compiled into a wasm package, and included directly in the extension. Unfortunately, `tree-sitter` and the surrounding ecosystem has truly been a nightmare to try and get started in.