### PR TITLE
Adjust Godot version detection regex

### DIFF
--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -109,7 +109,7 @@ export class ServerController {
 		try {
 			log.info(`Verifying version of '${godotPath}'`);
 			const output = execSync(`${godotPath} --version`).toString().trim();
-			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?\w+.\w+.[0-9a-f]{9}/;
+			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?(?:\w+\.)+[0-9a-f]{9}/;
 			const match = output.match(pattern);
 			if (!match) {
 				const message = `Cannot launch debug session: '${settingName}' of '${godotPath}' is not a valid Godot executable`;

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -110,7 +110,7 @@ export class ServerController {
 		try {
 			log.info(`Verifying version of '${godotPath}'`);
 			const output = execSync(`${godotPath} --version`).toString().trim();
-			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?\w+.\w+.[0-9a-f]{9}/;
+			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?(?:\w+\.)+[0-9a-f]{9}/;
 			const match = output.match(pattern);
 			if (!match) {
 				const message = `Cannot launch debug session: '${settingName}' of '${godotPath}' is not a valid Godot executable`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ function open_workspace_with_editor() {
 
 	try {
 		const output = execSync(`${godotPath} --version`).toString().trim();
-		const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?\w+.\w+.[0-9a-f]{9}/;
+		const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?(?:\w+\.)+[0-9a-f]{9}/;
 		const match = output.match(pattern);
 		if (!match) {
 			const message = `Cannot launch Godot editor: '${settingName}' of '${godotPath}' is not a valid Godot executable`;

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -110,7 +110,7 @@ export class ClientConnectionManager {
 
 		try {
 			const output = execSync(`${godotPath} --version`).toString().trim();
-			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?\w+.\w+.[0-9a-f]{9}/;
+			const pattern = /([34])\.([0-9]+)\.(?:[0-9]+\.)?(?:\w+\.)+[0-9a-f]{9}/;
 			const match = output.match(pattern);
 			if (!match) {
 				const message = `Cannot launch headless LSP: '${settingName}' of '${godotPath}' is not a valid Godot executable`;


### PR DESCRIPTION
The previous version detection would fail to detect some versions of godot (e.g 4.1.1.stable.mono.official.bd6af8e0e), resulting in an unclear error message. This commit makes a minor change to slightly improve the robustness of the version detection regex.

With this change I can run and debug my project with godot 4.1.1, and breakpoints even work 😄 