### PR TITLE
Open documentation from "go to definition" on native symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ experience as comfortable as possible:
 - In-editor Scene Preview
 - Display script warnings and errors
 - Ctrl + click on a variable or method call to jump to its definition
-- Full documentation of the Godot Engine's API supported (select *Godot Tools: List native classes of Godot* in the Command Palette)
+- Open Godot documentation when Ctrl + clicking native classes, methods, and properties
 - Run a Godot project from VS Code
 - Debug your GDScript-based Godot project from VS Code with breakpoints, step-in/out/over, variable watch, call stack, and active scene tree
 

--- a/package.json
+++ b/package.json
@@ -261,6 +261,25 @@
 					"default": false,
 					"description": "Force the project to run with visible navigation meshes"
 				},
+				"godotTools.documentation.method": {
+					"enum": [
+						"web",
+						"webOpenExternal",
+						"local"
+					],
+					"enumDescriptions": [
+						"Open online Godot documentation within VSCode",
+						"Open online Godot documentation in default browser",
+						"Open local Godot documentation in VSCode"
+					],
+					"default": "web",
+					"description": "Which method to use for opening Godot documentation"
+				},
+				"godotTools.documentation.webUrl": {
+					"type": "string",
+					"default": "https://docs.godotengine.org/en/stable",
+					"description": "URL to use when opening online Godot documentation"
+				},
 				"godotTools.documentation.newTabPlacement": {
 					"enum": [
 						"active",

--- a/src/lsp/gdscript.capabilities.ts
+++ b/src/lsp/gdscript.capabilities.ts
@@ -9,7 +9,7 @@ export const enum Methods {
 
 export interface NativeSymbolInspectParams {
 	native_class: string;
-	symbol_name: string;
+	symbol_name?: string;
 }
 
 export class GodotNativeSymbol implements DocumentSymbol {


### PR DESCRIPTION
This has been bothering me for a while, so figured I'd do something about it.

https://github.com/godotengine/godot-vscode-plugin/assets/46084870/2f087dd0-5ef7-41d8-b6eb-525ce2f4ea69

Added the following settings to control this behaviour:

- `godotTools.documentation.method` (`web`, `webExternal` or `local`)
- `godotTools.documentation.webUrl` (_default: https://docs.godotengine.org/en/stable_)

The GDScript LSP can sometimes struggle to resolve a symbol and returns multiple types

![image](https://github.com/godotengine/godot-vscode-plugin/assets/46084870/4e984447-c4e3-464f-bff0-f98f536a1789)

You _can_ cast the value to get around this, but I opted to add a QuickPick menu to allow you to select from the given options


https://github.com/godotengine/godot-vscode-plugin/assets/46084870/dc21a637-445a-4ab8-9f94-c1d9477f3328


- [ ] Test with Godot 3.x LSP
- [ ] Fix hovering a symbol with CTRL held (no clicking) triggering documentation open