### PR TITLE
Fix variables with leading underscores

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -202,7 +202,7 @@
 					"name": "constant.numeric.float.gdscript"
 				},
 				{
-					"match": "[-]?[0-9_]+",
+					"match": "[-]?[0-9](_[0-9]+)?+",
 					"name": "constant.numeric.integer.gdscript"
 				}
 			]


### PR DESCRIPTION
The integer literal regex was breaking variables with leading underscores. This PR should fix that.