### PR TITLE
Launching the editor opens a new custom terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,16 @@
 					"default": "godot4",
 					"description": "The absolute path to the Godot 4 editor executable"
 				},
+				"godotTools.editor.verbose": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to launch the Godot Editor with the --verbose flag"
+				},
+				"godotTools.editor.revealTerminal": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to reveal the terminal when launching the Godot Editor"
+				},
 				"godotTools.lsp.serverProtocol": {
 					"type": [
 						"string"


### PR DESCRIPTION
Per feedback from @KoBeWi, this PR moves the process started by `Open Workspace with Godot Editor` back to a terminal (instead of a headless child process).

This time the terminal is implemented correctly, with a name + icon, and doesn't have a lingering prompt that you really shouldn't use. It also prints that the editor was stopped and what the exit code was.

![image](https://github.com/godotengine/godot-vscode-plugin/assets/18042232/83ba7e68-d567-44e7-b489-3a4ebc3a0e06)

Notes:
- Killing the terminal in VSCode (trash can button) kills the Godot Editor.
- Closing the Godot Editor _does not_ kill the terminal, just in case there's some output you wanted to see.
- Running `Open Workspace with Godot Editor` again will close any existing windows and start a new one. I don't see a reason to open the same workspace multiple times.
- new settings:
	- `godotTools.editor.verbose`: Whether to launch the Godot Editor with the --verbose flag
	- `godotTools.editor.reveal`: Whether to reveal the terminal when launching the Godot Editor