### PR TITLE
fix Godot4.x debug console print multiple logs into one line.

### DIFF
--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -394,9 +394,8 @@ export class ServerController {
 					// this.request_scene_tree();
 				}
 				const lines = command.parameters[0];
-				for (const line of lines){
+				for (const line of lines) {
 					debug.activeDebugConsole.appendLine(line);
-					
 				}
 				break;
 			}

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -393,8 +393,11 @@ export class ServerController {
 					this.didFirstOutput = true;
 					// this.request_scene_tree();
 				}
-
-				debug.activeDebugConsole.appendLine(command.parameters[0]);
+				const lines = command.parameters[0];
+				for (const line of lines){
+					debug.activeDebugConsole.appendLine(line);
+					
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
Before fix
![Snipaste_2024-01-19_20-18-53](https://github.com/godotengine/godot-vscode-plugin/assets/1620585/8346ae02-13bf-4096-8515-f57114924906)

After fix
![Snipaste_2024-01-19_20-11-33](https://github.com/godotengine/godot-vscode-plugin/assets/1620585/f112b06d-f7e2-49a4-9920-b789ad51bcdc)

The server_controller of Godot 3 has no this bug.  So only fix for Godot 4.