### PR TITLE
Improve path handling when starting processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.vsix
 .vscode-test
 workspace.code-workspace
+.history

--- a/package.json
+++ b/package.json
@@ -226,12 +226,12 @@
 				"godotTools.editorPath.godot3": {
 					"type": "string",
 					"default": "godot3",
-					"description": "The absolute path to the Godot 3 editor executable"
+					"description": "Path to the Godot 3 editor executable"
 				},
 				"godotTools.editorPath.godot4": {
 					"type": "string",
 					"default": "godot4",
-					"description": "The absolute path to the Godot 4 editor executable"
+					"description": "Path to the Godot 4 editor executable"
 				},
 				"godotTools.editor.verbose": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -266,6 +266,8 @@
 				"godotTools.lsp.serverPort": {
 					"type": "number",
 					"default": 6008,
+					"minimum": 0,
+					"maximum": 65535,
 					"description": "The server port of the GDScript language server"
 				},
 				"godotTools.lsp.headless": {

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -138,6 +138,17 @@ export class GodotDebugger implements DebugAdapterDescriptorFactory, DebugConfig
 				config.project = "${workspaceFolder}";
 			}
 		}
+
+		if (typeof config.port !== "number" || config.port < -1 || config.port > 65535) {
+			window.showErrorMessage("Can't launch debug session: 'port' must be a number between -1 and 65535.", "Ok");
+			return undefined;
+		}
+
+		if (config.address.includes("://")) {
+			window.showErrorMessage("Can't launch debug session: 'address' cannot include a protocol.", "Ok");
+			return undefined;
+		}
+
 		return config;
 	}
 

--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -101,27 +101,62 @@ export class ServerController {
 
 	private async start_game(args: LaunchRequestArguments) {
 		log.info("Starting game process");
-		const settingName = "editorPath.godot3";
-		const godotPath: string = get_configuration(settingName);
 
-		log.info(`Verifying version of '${godotPath}'`);
-		const result = verify_godot_version(godotPath, "3");
+		let godotPath: string;
+		let result;
+		if (args.editor_path) {
+			log.info("Using 'editor_path' variable from launch.json");
 
-		log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+			godotPath = args.editor_path;
 
-		switch (result.status) {
-			case "WRONG_VERSION": {
-				const projectVersion = await get_project_version();
-				const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
-				log.warn(message);
-				prompt_for_godot_executable(message, settingName);
-				return;
+			log.info(`Verifying version of '${godotPath}'`);
+			result = verify_godot_version(godotPath, "3");
+
+			log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+			switch (result.status) {
+				case "WRONG_VERSION": {
+					const projectVersion = await get_project_version();
+					const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
+					log.warn(message);
+					window.showErrorMessage(message, "Ok");
+					this.abort();
+					return;
+				}
+				case "INVALID_EXE": {
+					const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
+					log.warn(message);
+					window.showErrorMessage(message, "Ok");
+					this.abort();
+					return;
+				}
 			}
-			case "INVALID_EXE": {
-				const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
-				log.warn(message);
-				prompt_for_godot_executable(message, settingName);
-				return;
+		} else {
+			log.info("Using 'editorPath.godot3' from settings");
+
+			const settingName = "editorPath.godot3";
+			godotPath = get_configuration(settingName);
+
+			log.info(`Verifying version of '${godotPath}'`);
+			result = verify_godot_version(godotPath, "3");
+
+			log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+
+			switch (result.status) {
+				case "WRONG_VERSION": {
+					const projectVersion = await get_project_version();
+					const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
+					log.warn(message);
+					prompt_for_godot_executable(message, settingName);
+					this.abort();
+					return;
+				}
+				case "INVALID_EXE": {
+					const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
+					log.warn(message);
+					prompt_for_godot_executable(message, settingName);
+					this.abort();
+					return;
+				}
 			}
 		}
 

--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -107,7 +107,8 @@ export class ServerController {
 		log.info(`Verifying version of '${godotPath}'`);
 		const result = verify_godot_version(godotPath, "3");
 
-		log.info("Got version string:", result);
+		log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+
 		switch (result.status) {
 			case "WRONG_VERSION": {
 				const projectVersion = await get_project_version();

--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -107,7 +107,7 @@ export class ServerController {
 		if (args.editor_path) {
 			log.info("Using 'editor_path' variable from launch.json");
 
-			godotPath = args.editor_path;
+			godotPath = args.editor_path.replace(/^"/, "").replace(/"$/, "");
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "3");
@@ -134,7 +134,7 @@ export class ServerController {
 			log.info("Using 'editorPath.godot3' from settings");
 
 			const settingName = "editorPath.godot3";
-			godotPath = get_configuration(settingName);
+			godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "3");

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -108,7 +108,8 @@ export class ServerController {
 		log.info(`Verifying version of '${godotPath}'`);
 		const result = verify_godot_version(godotPath, "4");
 
-		log.info("Got version string:", result);
+		log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+
 		switch (result.status) {
 			case "WRONG_VERSION": {
 				const projectVersion = await get_project_version();
@@ -480,7 +481,7 @@ export class ServerController {
 
 	private send_command(command: string, parameters?: any[]) {
 		const commandArray: any[] = [command];
-		log.debug("send_command", this.connectedVersion);
+		// log.debug("send_command", this.connectedVersion);
 		if (this.connectedVersion[2] >= "2") {
 			commandArray.push(this.threadId);
 		}

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -108,7 +108,7 @@ export class ServerController {
 		if (args.editor_path) {
 			log.info("Using 'editor_path' variable from launch.json");
 
-			godotPath = args.editor_path;
+			godotPath = args.editor_path.replace(/^"/, "").replace(/"$/, "");
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "4");
@@ -135,7 +135,7 @@ export class ServerController {
 			log.info("Using 'editorPath.godot4' from settings");
 
 			const settingName = "editorPath.godot4";
-			godotPath = get_configuration(settingName);
+			godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "4");

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -102,27 +102,62 @@ export class ServerController {
 
 	private async start_game(args: LaunchRequestArguments) {
 		log.info("Starting game process");
-		const settingName = "editorPath.godot4";
-		const godotPath: string = get_configuration(settingName);
 
-		log.info(`Verifying version of '${godotPath}'`);
-		const result = verify_godot_version(godotPath, "4");
+		let godotPath: string;
+		let result;
+		if (args.editor_path) {
+			log.info("Using 'editor_path' variable from launch.json");
 
-		log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+			godotPath = args.editor_path;
 
-		switch (result.status) {
-			case "WRONG_VERSION": {
-				const projectVersion = await get_project_version();
-				const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
-				log.warn(message);
-				prompt_for_godot_executable(message, settingName);
-				return;
+			log.info(`Verifying version of '${godotPath}'`);
+			result = verify_godot_version(godotPath, "4");
+
+			log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+			switch (result.status) {
+				case "WRONG_VERSION": {
+					const projectVersion = await get_project_version();
+					const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
+					log.warn(message);
+					window.showErrorMessage(message, "Ok");
+					this.abort();
+					return;
+				}
+				case "INVALID_EXE": {
+					const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
+					log.warn(message);
+					window.showErrorMessage(message, "Ok");
+					this.abort();
+					return;
+				}
 			}
-			case "INVALID_EXE": {
-				const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
-				log.warn(message);
-				prompt_for_godot_executable(message, settingName);
-				return;
+		} else {
+			log.info("Using 'editorPath.godot4' from settings");
+
+			const settingName = "editorPath.godot4";
+			godotPath = get_configuration(settingName);
+
+			log.info(`Verifying version of '${godotPath}'`);
+			result = verify_godot_version(godotPath, "4");
+
+			log.info(`Verification result: ${result.status}, version: "${result.version}"`);
+
+			switch (result.status) {
+				case "WRONG_VERSION": {
+					const projectVersion = await get_project_version();
+					const message = `Cannot launch debug session: The current project uses Godot v${projectVersion}, but the specified Godot executable is v${result.version}`;
+					log.warn(message);
+					prompt_for_godot_executable(message, settingName);
+					this.abort();
+					return;
+				}
+				case "INVALID_EXE": {
+					const message = `Cannot launch debug session: '${godotPath}' is not a valid Godot executable`;
+					log.warn(message);
+					prompt_for_godot_executable(message, settingName);
+					this.abort();
+					return;
+				}
 			}
 		}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ async function open_workspace_with_editor() {
 	const projectVersion = await get_project_version();
 
 	const settingName = `editorPath.godot${projectVersion[0]}`;
-	const godotPath = get_configuration(settingName);
+	const godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
 	const result = verify_godot_version(godotPath, projectVersion[0]);
 
 	switch (result.status) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,7 +157,7 @@ async function open_workspace_with_editor() {
 
 	switch (result.status) {
 		case "SUCCESS": {
-			let command = `${godotPath} --path "${projectDir}" -e`;
+			let command = `"${godotPath}" --path "${projectDir}" -e`;
 			if (get_configuration("editor.verbose")) {
 				command += " -v";
 			}

--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -30,7 +30,7 @@ const registry = new vsctm.Registry({
 		if (scopeName === "source.gdscript") {
 			return readFile(grammarPath).then(data => vsctm.parseRawGrammar(data.toString(), grammarPath));
 		}
-		console.log(`Unknown scope name: ${scopeName}`);
+		// console.log(`Unknown scope name: ${scopeName}`);
 		return null;
 	}
 });

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -105,7 +105,7 @@ export class ClientConnectionManager {
 			targetVersion = "4.2";
 		}
 		const settingName = `editorPath.godot${projectVersion[0]}`;
-		const godotPath = get_configuration(settingName);
+		const godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
 
 		const result = verify_godot_version(godotPath, projectVersion[0]);
 		switch (result.status) {
@@ -142,7 +142,7 @@ export class ClientConnectionManager {
 		log.info(`starting headless LSP on port ${this.client.port}`);
 
 		const headlessFlags = "--headless --no-window";
-		const command = `${godotPath} --path "${projectDir}" --editor ${headlessFlags} --lsp-port ${this.client.port}`;
+		const command = `"${godotPath}" --path "${projectDir}" --editor ${headlessFlags} --lsp-port ${this.client.port}`;
 		const lspProcess = subProcess("LSP", command, { shell: true, detached: true });
 
 		const lspStdout = createLogger("lsp.stdout");

--- a/src/utils/project_utils.ts
+++ b/src/utils/project_utils.ts
@@ -80,7 +80,7 @@ type VERIFY_RESULT = {
 
 export function verify_godot_version(godotPath: string, expectedVersion: "3" | "4" | string): VERIFY_RESULT {
 	try {
-		const output = execSync(`${godotPath} -h`).toString().trim();
+		const output = execSync(`"${godotPath}" -h`).toString().trim();
 		const pattern = /^Godot Engine v(([34])\.([0-9]+)(?:\.[0-9]+)?)/;
 		const match = output.match(pattern);
 		if (!match) {


### PR DESCRIPTION
This should resolve #570 and #574.

`editorPath.godot3/4` setting and `editor_path` debug configuration now correctly handle paths with spaces or surrounded with quotes.

The Godot exe version check was missing quotes, so paths with strings were failing the test even thought the actual debugger handles it correctly.

Added validation to the debug config values for `address` and `port` to prevent weird, obviously wrong stuff from happening.

Fixed the debug config value `editor_path` not being used.

Also applied better path handling to "launch godot editor" command.