### PR TITLE
Expose Godot path as getGodotPath command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
 		register_command("copyResourcePath", copy_resource_path),
 		register_command("listGodotClasses", list_classes),
 		register_command("switchSceneScript", switch_scene_script),
+		register_command("getGodotPath", get_godot_path),
 	);
 
 	set_context("godotFiles", ["gdscript", "gdscene", "gdresource", "gdshader",]);
@@ -77,6 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
 		initial_setup();
 	});
 }
+
 
 async function initial_setup() {
 	const projectVersion = await get_project_version();
@@ -89,14 +91,14 @@ async function initial_setup() {
 			break;
 		}
 		case "WRONG_VERSION": {
-			const message = `The specified Godot executable, '${godotPath}' is the wrong version. 
+			const message = `The specified Godot executable, '${godotPath}' is the wrong version.
 				The current project uses Godot v${projectVersion}, but the specified executable is Godot v${result.version}.
 				Extension features will not work correctly unless this is fixed.`;
 			prompt_for_godot_executable(message, settingName);
 			break;
 		}
 		case "INVALID_EXE": {
-			const message = `The specified Godot executable, '${godotPath}' is invalid. 
+			const message = `The specified Godot executable, '${godotPath}' is invalid.
 				Extension features will not work correctly unless this is fixed.`;
 			prompt_for_godot_executable(message, settingName);
 			break;
@@ -188,6 +190,20 @@ async function open_workspace_with_editor() {
 			break;
 		}
 	}
+}
+
+/**
+ * Returns the executable path for Godot based on the current project's version.
+ * Created to allow other extensions to get the path without having to go
+ * through the steps of determining the version to get the proper configuration
+ * value (godotTools.editorPath.godot3/4).
+ * @returns
+ */
+async function get_godot_path() : Promise<string>{
+	const projectVersion = await get_project_version();
+	const settingName = `editorPath.godot${projectVersion[0]}`;
+	const godotPath : string = get_configuration(settingName);//.replace(/^"/, "").replace(/"$/, "");?
+	return godotPath;
 }
 
 class GodotEditorTerminal implements vscode.Pseudoterminal {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,8 +198,11 @@ async function open_workspace_with_editor() {
  * value (godotTools.editorPath.godot3/4).
  * @returns
  */
-async function get_godot_path() : Promise<string>{
+async function get_godot_path(): Promise<string|undefined> {
 	const projectVersion = await get_project_version();
+	if (projectVersion === undefined) {
+		return undefined;
+	}
 	const settingName = `editorPath.godot${projectVersion[0]}`;
 	// Cleans up any surrounding quotes the user might put into the path.
 	const godotPath : string = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,8 @@ async function open_workspace_with_editor() {
 async function get_godot_path() : Promise<string>{
 	const projectVersion = await get_project_version();
 	const settingName = `editorPath.godot${projectVersion[0]}`;
-	const godotPath : string = get_configuration(settingName);//.replace(/^"/, "").replace(/"$/, "");?
+	// Cleans up any surrounding quotes the user might put into the path.
+	const godotPath : string = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
 	return godotPath;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,6 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 }
 
-
 async function initial_setup() {
 	const projectVersion = await get_project_version();
 	const settingName = `editorPath.godot${projectVersion[0]}`;
@@ -91,14 +90,14 @@ async function initial_setup() {
 			break;
 		}
 		case "WRONG_VERSION": {
-			const message = `The specified Godot executable, '${godotPath}' is the wrong version.
+			const message = `The specified Godot executable, '${godotPath}' is the wrong version. 
 				The current project uses Godot v${projectVersion}, but the specified executable is Godot v${result.version}.
 				Extension features will not work correctly unless this is fixed.`;
 			prompt_for_godot_executable(message, settingName);
 			break;
 		}
 		case "INVALID_EXE": {
-			const message = `The specified Godot executable, '${godotPath}' is invalid.
+			const message = `The specified Godot executable, '${godotPath}' is invalid. 
 				Extension features will not work correctly unless this is fixed.`;
 			prompt_for_godot_executable(message, settingName);
 			break;

--- a/src/utils/project_utils.ts
+++ b/src/utils/project_utils.ts
@@ -81,7 +81,7 @@ type VERIFY_RESULT = {
 export function verify_godot_version(godotPath: string, expectedVersion: "3" | "4" | string): VERIFY_RESULT {
 	try {
 		const output = execSync(`"${godotPath}" -h`).toString().trim();
-		const pattern = /^Godot Engine v(([34])\.([0-9]+)(?:\.[0-9]+)?)/;
+		const pattern = /^Godot Engine v(([34])\.([0-9]+)(?:\.[0-9]+)?)/m;
 		const match = output.match(pattern);
 		if (!match) {
 			return { status: "INVALID_EXE" };

--- a/src/utils/project_utils.ts
+++ b/src/utils/project_utils.ts
@@ -3,19 +3,29 @@ import * as path from "path";
 import * as fs from "fs";
 import { execSync } from "child_process";
 
-let projectDir = undefined;
-let projectFile = undefined;
+let projectDir: string | undefined = undefined;
+let projectFile: string | undefined = undefined;
 
-export async function get_project_dir() {
+export async function get_project_dir(): Promise<string | undefined> {
 	let file = "";
 	if (vscode.workspace.workspaceFolders != undefined) {
 		const files = await vscode.workspace.findFiles("**/project.godot");
-		// if multiple project files, pick the top-most one
-		const best = files.reduce((a, b) => a.fsPath.length <= b.fsPath.length ? a : b);
-		if (best) {
-			file = best.fsPath;
+
+		if (files.length == 0) {
+			return undefined;
+		} else if (files.length == 1) {
+			file = files[0].fsPath;
 			if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
-				return;
+				return undefined;
+			}
+		} else if (files.length > 1) {
+			// if multiple project files, pick the top-most one
+			const best = files.reduce((a, b) => a.fsPath.length <= b.fsPath.length ? a : b);
+			if (best) {
+				file = best.fsPath;
+				if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+					return undefined;
+				}
 			}
 		}
 	}
@@ -24,12 +34,17 @@ export async function get_project_dir() {
 	return projectDir;
 }
 
-let projectVersion = undefined;
+let projectVersion: string | undefined = undefined;
 
 export async function get_project_version(): Promise<string | undefined> {
 	if (projectDir === undefined || projectFile === undefined) {
 		await get_project_dir();
 	}
+
+	if (projectFile === undefined) {
+		return undefined;
+	}
+
 	let godotVersion = "3.x";
 	const document = await vscode.workspace.openTextDocument(projectFile);
 	const text = document.getText();


### PR DESCRIPTION
## Overview
This PR adds a `godotTools.getGodotPath` command so that other extensions that rely on this one can get the path to the executable without having to determine the version of the current project and then decide which configuration value to use (`godotTools.editorPath.godot3/4`).

Usage:
In another VSCode extension use the following to get the path to the Godot executable for the currently opened project
``` typescript
let editorPath : string = await vscode.commands.executeCommand('godotTools.getGodotPath');
```

## Justification
I maintain the [gut-extension](https://github.com/bitwes/gut-extension) plugin that allows you to run GUT unit tests through VSCode.  It was using `godot_tools.editor_path` to launch Godot.  I was starting to adjust my code to determine which configuration value to use when I realized that this extension should probably provide that functionality.  This makes it available to other extensions.  This also means that if the logic to get the path changes (such as when Godot 3 becomes unsupported) other extensions won't have to be updated.

## Questions:
1.  Should I create an issue for this first?
1.  I wasn't 100% sure what `.replace(/^"/, "").replace(/"$/, "");` was accomplishing so I left it as a comment inside the new `get_godot_path` function.  Let me know if it should be included or not and I will update the PR.
2. I had to update the regex pattern used in `verify_godot_version` to get this to run using version 3.5.3 on a Mac/zsh.  I added `m` to the end so it would find the version regardless of which line it appears on.  The `-h` flag is spitting out the arguments passed to Godot first, so the "Godot Engine" line was not being found.  Let me know if I should remove this and make another PR and/or Issue.

Here's the start of my Godot 3.5.3 `-h` Output:
```
arguments
0: /Applications/Godot_3.5.3.app/Contents/MacOS/Godot
1: -h
Current path: /Users/butchwesley/development/godot/guts/gut-extension/GodotTestProject/Godot3
Godot Engine v3.5.3.stable.official.6c814135b - https://godotengine.org
Free and open source software under the terms of the MIT license.
(c) 2014-present Godot Engine contributors.
(c) 2007-2014 Juan Linietsky, Ariel Manzur.

...
```