### PR TITLE
Add basic inlay hint support for GDScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,6 +303,16 @@
 					],
 					"default": "sameFolder",
 					"description": "Controls where the Scene Preview will search for related scenes when viewing a script file."
+				},
+				"godotTools.inlayHints.gdscript": {
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to enable inlay variable hints for GDScript's inferred variables"
+						}
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -305,14 +305,14 @@
 					"description": "Controls where the Scene Preview will search for related scenes when viewing a script file."
 				},
 				"godotTools.inlayHints.gdscript": {
-					"type": "object",
-					"properties": {
-						"enabled": {
-							"type": "boolean",
-							"default": true,
-							"description": "Whether to enable inlay variable hints for GDScript's inferred variables"
-						}
-					}
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to enable inlay hints in GDScript files"
+				},
+				"godotTools.inlayHints.gdresource": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to enable inlay hints in GDResource (.tscn, .tres, etc) files"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -306,8 +306,8 @@
 				},
 				"godotTools.inlayHints.gdscript": {
 					"type": "boolean",
-					"default": true,
-					"description": "Whether to enable inlay hints in GDScript files"
+					"default": false,
+					"description": "Whether to enable inlay hints in GDScript files (experimental)"
 				},
 				"godotTools.inlayHints.gdresource": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
 					"properties": {
 						"enabled": {
 							"type": "boolean",
-							"default": false,
+							"default": true,
 							"description": "Whether to enable inlay variable hints for GDScript's inferred variables"
 						}
 					}

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -81,7 +81,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 			// since neither LSP or the grammar know whether a variable is inferred or not,
 			// we still need to use regex to find all inferred variable declarations.
-			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
+			const regex = /((^|\r?\n)\s*(@?[\w\d_"()\s,'])+\s*(var|const)\s+)([\w\d_]+)\s*:=/g;
 			
 			for (const match of text.matchAll(regex)) {
 				if (token.isCancellationRequested) break;

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -63,15 +63,17 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 			// TODO: use regex only on ranges provided by the LSP
 			// since the LSP doesn't know whether a variable is inferred or not,
-			// we still need to use regex to find inferred variables
-			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?var[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
+			// we still need to use regex to find inferred variables.
+
+			// matches variables
+			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			
 			for (const match of text.matchAll(regex)) {
 				const start = document.positionAt(match.index + match[0].length - 1);
 				if (hasDetail) {
 					// godot 4.0+ automatically provides the "detail" field, allowing us to skip
 					// the extra hover request
-					const symbol = symbols.find((s: any) => s.name === match[5]);
+					const symbol = symbols.find((s: any) => s.name === match[6]);
 					if (symbol && symbol["detail"]) {
 						const hint = new InlayHint(start, fromDetail(symbol["detail"]), InlayHintKind.Type);
 						hints.push(hint);

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -10,7 +10,7 @@ import {
 	ExtensionContext,
 } from "vscode";
 import { SceneParser } from "../scene_tools";
-import { createLogger } from "../utils";
+import { createLogger, get_configuration } from "../utils";
 import { globals } from "../extension";
 
 const log = createLogger("providers.inlay_hints");
@@ -56,6 +56,10 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 		const text = document.getText();
 
 		if (document.fileName.endsWith(".gd")) {
+			if (!get_configuration("inlayHints.gdscript", true)) {
+				return hints;
+			}
+
 			await globals.lsp.client.onReady();
 
 			const symbolsRequest = await globals.lsp.client.sendRequest("textDocument/documentSymbol", {
@@ -74,7 +78,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 			// TODO: use regex only on ranges provided by the LSP (textDocument/documentSymbol)
 
-			// since the LSP doesn't know whether a variable is inferred or not,
+			// since neither LSP or the grammar know whether a variable is inferred or not,
 			// we still need to use regex to find all inferred variable declarations.
 			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -76,7 +76,8 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 			const hasDetail = symbols.some((s: any) => s.detail);
 
-			// TODO: use regex only on ranges provided by the LSP (textDocument/documentSymbol)
+			// TODO: make sure godot reports the correct location for variable declaration symbols
+			// (allowing the use of regex only on ranges provided by the LSP (textDocument/documentSymbol))
 
 			// since neither LSP or the grammar know whether a variable is inferred or not,
 			// we still need to use regex to find all inferred variable declarations.

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -117,6 +117,10 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 			return hints;
 		}
 
+		if (!get_configuration("inlayHints.gdresource", true)) {
+			return hints;
+		}
+
 		const scene = this.parser.parse_scene(document);
 
 		for (const match of text.matchAll(/ExtResource\(\s?"?(\w+)\s?"?\)/g)) {

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -81,7 +81,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 			// since neither LSP or the grammar know whether a variable is inferred or not,
 			// we still need to use regex to find all inferred variable declarations.
-			const regex = /((^|\r?\n)\s*(@?[\w\d_"()\s,'])+\s*(var|const)\s+)([\w\d_]+)\s*:=/g;
+			const regex = /((var|const)\s+)([\w\d_]+)\s*:=/g;
 			
 			for (const match of text.matchAll(regex)) {
 				if (token.isCancellationRequested) break;
@@ -91,7 +91,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 				const hoverPosition = document.positionAt(match.index + match[1].length);
 
 				if (hasDetail) {
-					const symbol = symbols.find((s: any) => s.name === match[6]);
+					const symbol = symbols.find((s: any) => s.name === match[3]);
 					if (symbol && symbol["detail"]) {
 						const hint = new InlayHint(start, fromDetail(symbol["detail"]), InlayHintKind.Type);
 						hints.push(hint);

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -53,7 +53,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 	async provideInlayHints(document: TextDocument, range: Range, token: CancellationToken): Promise<InlayHint[]> {
 		const hints: InlayHint[] = [];
-		const text = document.getText();
+		const text = document.getText(range);
 
 		if (document.fileName.endsWith(".gd")) {
 			if (!get_configuration("inlayHints.gdscript", true)) {
@@ -83,6 +83,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			
 			for (const match of text.matchAll(regex)) {
+				if (token.isCancellationRequested) break;
 				// TODO: until godot supports nested document symbols, we need to send
 				// a hover request for each variable declaration that is nested
 				const start = document.positionAt(match.index + match[0].length - 1);

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -77,10 +77,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 			// we still need to use regex to find inferred variables.
 
 			// matches all variable declarations
-			const regex = hasDetail ?
-				/((^|\r?\n)[\t\s]+(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g :
-				/((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
-				// note the      ^ character
+			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			
 			for (const match of text.matchAll(regex)) {
 				// TODO: until godot supports nested document symbols, we need to send

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -73,10 +73,9 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 			const hasDetail = symbols.some((s: any) => s.detail);
 
 			// TODO: use regex only on ranges provided by the LSP (textDocument/documentSymbol)
-			// since the LSP doesn't know whether a variable is inferred or not,
-			// we still need to use regex to find inferred variables.
 
-			// matches all variable declarations
+			// since the LSP doesn't know whether a variable is inferred or not,
+			// we still need to use regex to find all inferred variable declarations.
 			const regex = /((^|\r?\n)[\t\s]*(@?[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?(var|const)[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			
 			for (const match of text.matchAll(regex)) {

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -34,13 +34,19 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 		const text = document.getText();
 
 		if (document.fileName.endsWith(".gd")) {
-			const regex = /(^|\r?\n)[\t\s]*(@[\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?var[\t\s]+([\w\d_]+)[\t\s]*:=/g;
+			await globals.lsp.client.onReady();
+
+			// for godot 3, no information on the symbol types
+			const regex = /((^|\r?\n)[\t\s]*([\w\d_"()\t\s,']+([\t\s]|\r?\n)+)?var[\t\s]+)([\w\d_]+)[\t\s]*:=/g;
 			for (const match of text.matchAll(regex)) {
 				const start = document.positionAt(match.index + match[0].length - 1);
-
+				const hoverPosition = document.positionAt(match.index + match[1].length);
 				const response = await globals.lsp.client.sendRequest("textDocument/hover", {
 					textDocument: { uri: document.uri.toString() },
-					position: document.positionAt(match.index + match[0].length - 3),
+					position: {
+						line: hoverPosition.line,
+						character: hoverPosition.character,
+					}
 				});
 				const fullLabel = response["contents"].value;
 				const labelRegex = /: ([\w\d_]+)/;


### PR DESCRIPTION
Adds #588, creating inlay hints in GDScript files

![image](https://github.com/godotengine/godot-vscode-plugin/assets/26509014/04e776ae-d9d5-4628-9343-8ed0637af6ea)

Currently works with Godot 3.x and 4.x (tested on the latest stable of both; 4.2 and 3.5.3)
