### PR TITLE
Fix version check of Godot binary 

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
 				},
 				"godotTools.editorPath.godot4": {
 					"type": "string",
-					"default": "godot4",
+					"default": "godot",
 					"description": "Path to the Godot 4 editor executable"
 				},
 				"godotTools.editor.verbose": {

--- a/src/utils/project_utils.ts
+++ b/src/utils/project_utils.ts
@@ -95,8 +95,8 @@ type VERIFY_RESULT = {
 
 export function verify_godot_version(godotPath: string, expectedVersion: "3" | "4" | string): VERIFY_RESULT {
 	try {
-		const output = execSync(`"${godotPath}" -h`).toString().trim();
-		const pattern = /^Godot Engine v(([34])\.([0-9]+)(?:\.[0-9]+)?)/m;
+		const output = execSync(`"${godotPath}" --version`).toString().trim();
+		const pattern = /^(([34])\.([0-9]+)(?:\.[0-9]+)?)/m;
 		const match = output.match(pattern);
 		if (!match) {
 			return { status: "INVALID_EXE" };


### PR DESCRIPTION
I was using --help to check the version of the specified Godot binary, because it's output is more specific (it includes the words "Godot Engine").

However, Godot 4.3 adds color to the output of --help, and this breaks the regex used to validate the version number.

The extra strictness of using --help is probably overkill, so I'm just switching back to --version.

This PR also changes the default value of `godotTools.editorPath.godot4` from `godot4` to just `godot`.

fixes #585