### PR TITLE
Syntax highlighting fixes

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -244,6 +244,14 @@
 			"end": "$|;",
 			"patterns": [
 				{
+					"match": "(:)?\\s*(set|get)\\s+=\\s+([a-zA-Z_]\\w*)",
+					"captures": {
+						"1": { "name": "punctuation.separator.annotation.gdscript" },
+						"2": { "name": "keyword.language.gdscript storage.type.const.gdscript" },
+						"3": { "name": "entity.name.function.gdscript" }
+					}
+				},
+				{
 					"match": ":=|=(?!=)",
 					"name": "keyword.operator.assignment.gdscript"
 				},

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -74,6 +74,7 @@
 				{ "include": "#function_call" },
 				{ "include": "#comment" },
 				{ "include": "#self" },
+				{ "include": "#func" },
 				{ "include": "#letter" },
 				{ "include": "#numbers" },
 				{ "include": "#builtin_classes" },
@@ -148,6 +149,10 @@
 		"self": {
 			"match": "\\bself\\b",
 			"name": "variable.language.gdscript"
+		},
+		"func": {
+			"match": "\\bfunc\\b",
+			"name": "keyword.language.gdscript"
 		},
 		"logic_operator": {
 			"match": "\\b(and|or|not|!)\\b",

--- a/syntaxes/examples/gdscript2.gd
+++ b/syntaxes/examples/gdscript2.gd
@@ -70,4 +70,13 @@ var warns_when_changed = "some value":
 		changed.emit(value)
 		warns_when_changed = value
 
+
+var inline_setter_getter: String = "test" : get = getter, set = setter
+
+func getter():
+	pass
+func setter(x):
+	pass
+
+
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
fixes #591

fixes single line set/get in Godot 4:

![image](https://github.com/godotengine/godot-vscode-plugin/assets/18042232/121d53e7-553f-4b65-9b3f-aa2c14970db5)
