### PR TITLE
Fix broken scene file parser

### DIFF
--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -84,12 +84,18 @@ export class SceneParser {
 		const nodes = {};
 		let lastNode = null;
 
-		const nodeRegex = /\[node name="([\w]*)"(?: type="([\w]*)")?(?: parent="([\w\/.]*)")?(?: instance=ExtResource\(\s*"?([\w]+)"?\s*\))?\]/g;
+		const nodeRegex = /\[node.*/g;
 		for (const match of text.matchAll(nodeRegex)) {
-			const name = match[1];
-			const type = match[2] ? match[2] : "PackedScene";
-			let parent = match[3];
-			const instance = match[4] ? match[4] : 0;
+			const line = match[0];
+			const name = line.match(/name="([\w]+)"/)?.[1];
+			const type = line.match(/type="([\w]+)"/)?.[1] ?? "PackedScene";
+			let parent = line.match(/parent="([\w\/.]+)"/)?.[1];
+			const instance = line.match(/instance=ExtResource\(\s*"?([\w]+)"?\s*\)/)?.[1];
+
+			// leaving this in case we have a reason to use these node paths in the future
+			// const rawNodePaths = line.match(/node_paths=PackedStringArray\(([\w",\s]*)\)/)?.[1];
+			// const nodePaths = rawNodePaths?.split(",").forEach(x => x.trim().replace("\"", ""));
+
 			let _path = "";
 			let relativePath = "";
 

--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -98,11 +98,11 @@ export class SceneParser {
 			} else if (parent === ".") {
 				parent = root;
 				relativePath = name;
-				_path = parent + "/" + name;
+				_path = `${parent}/${name}`;
 			} else {
-				relativePath = parent + "/" + name;
-				parent = root + "/" + parent;
-				_path = parent + "/" + name;
+				relativePath = `${parent}/${name}`;
+				parent = `${root}/${parent}`;
+				_path = `${parent}/${name}`;
 			}
 			if (lastNode) {
 				lastNode.body = text.slice(lastNode.position, match.index);

--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -12,6 +12,7 @@ export class SceneParser {
 
 	constructor() {
 		if (SceneParser.instance) {
+			// biome-ignore lint/correctness/noConstructorReturn: <explanation>
 			return SceneParser.instance;
 		}
 		SceneParser.instance = this;

--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -24,7 +24,7 @@ export class SceneParser {
 		if (this.scenes.has(path)) {
 			const scene = this.scenes.get(path);
 
-			if (scene.mtime == stats.mtimeMs) {
+			if (scene.mtime === stats.mtimeMs) {
 				return scene;
 			}
 		}
@@ -92,10 +92,10 @@ export class SceneParser {
 			let _path = "";
 			let relativePath = "";
 
-			if (parent == undefined) {
+			if (parent === undefined) {
 				root = name;
 				_path = name;
-			} else if (parent == ".") {
+			} else if (parent === ".") {
 				parent = root;
 				relativePath = name;
 				_path = parent + "/" + name;
@@ -136,7 +136,7 @@ export class SceneParser {
 				}
 				node.contextValue += "hasResourcePath";
 			}
-			if (_path == root) {
+			if (_path === root) {
 				scene.root = node;
 			}
 			if (parent in nodes) {


### PR DESCRIPTION
Fixes #600

The Scene Preview panel was failing to render certain scene files. The cause turned out to be a new(?) field in the node section header, `nodes_paths`.

These section headers were being found and parsed in a single overly-large regex, which did not tolerate the addition of the new field. The fix is splitting the work into one regex that finds the section header, and mutlple smaller regexes that extract each field individually.