### PR TITLE
Fix child processes not being killed properly

### DIFF
--- a/src/utils/subspawn.ts
+++ b/src/utils/subspawn.ts
@@ -28,7 +28,7 @@ export function killSubProcesses(owner: string) {
 				} else if (process.platform === "darwin") {
 					execSync(`kill -9 ${c.pid}`);
 				} else {
-					process.kill(c.pid);
+					process.kill(-c.pid);
 				}
 			}
 		} catch {


### PR DESCRIPTION
Currently, headless LSP processes continue running when VS Code exits on Linux.

**Simple steps to reproduce:**

1. Launch VS Code.

2. Check the headless processes ― for example, with `ps ajx | grep headless`.
   Here's the output on my machine:

   ```
   vpyatnitskiy@vpyatnitskiy-katana:~/tmp/godot-vscode-plugin$ ps ajx | grep headless
     26910   27154   27154   27154 ?             -1 Ss    1000   0:00 /bin/sh -c "/home/vpyatnitskiy/.local/share/Steam/steamapps/common/Godot Engine/godot.x11.opt.tools.64" --path "/home/vpyatnitskiy/godot-projects/Left or Right" --editor --headless --no-window --lsp-port 38661
     27154   27159   27154   27154 ?             -1 Rl    1000   0:01 /home/vpyatnitskiy/.local/share/Steam/steamapps/common/Godot Engine/godot.x11.opt.tools.64 --path /home/vpyatnitskiy/godot-projects/Left or Right --editor --headless --no-window --lsp-port 38661
      2292   27235   27234    2292 pts/1      27234 S+    1000   0:00 grep --color=auto headless
   ```

3. Close VS Code.

4. Check the processes again. Here's my output:

   ```
   vpyatnitskiy@vpyatnitskiy-katana:~/tmp/godot-vscode-plugin$ ps ajx | grep headless
         1   27159   27154   27154 ?             -1 Sl    1000   0:03 /home/vpyatnitskiy/.local/share/Steam/steamapps/common/Godot Engine/godot.x11.opt.tools.64 --path /home/vpyatnitskiy/godot-projects/Left or Right --editor --headless --no-window --lsp-port 38661
      2292   27290   27289    2292 pts/1      27289 R+    1000   0:00 grep --color=auto headless
   ```
   
As you can see, the shell process (`/bin/sh`) is gone, but the engine itself continues running. Each of those is half a gig of RAM ― relaunch a few times and it adds up.

**What happens here is:**

- `shell: true` causes `child_process.spawn()` to start a shell process which, in turn, starts Godot Engine. The returned PID is the shell's PID.

- Child processes are allowed to persist even when detached (see [Node.js documentation on `options.detached`](https://nodejs.org/api/child_process.html#optionsdetached)) ― so `process.kill()`ing the shell does not kill the engine.

Now, `options.detached` in this case makes Node start a new process group with the shell process as its leader; to terminate everything, the entire group needs to be killed. In the snippets above, you can see the group ID in the third column.

Process group IDs in Linux are equal to the PIDs of their leaders; to send a signal to a group, negative values for PID are used. See e.g. [this answer on StackOverflow](https://stackoverflow.com/a/33367711).

This PR makes it so that the kill signal is indeed dispatched to the group. It's a single character change, but I feel like it deserved a detailed explanation.