### PR TITLE
Fix debugged process not being terminated when debugging session closes on Linux

### DIFF
--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -221,7 +221,7 @@ export class ServerController {
 		}
 
 		log.info(`Launching game process using command: '${command}'`);
-		const debugProcess = subProcess("debug", command, { shell: true });
+		const debugProcess = subProcess("debug", command, { shell: true, detached: true });
 
 		debugProcess.stdout.on("data", (data) => { });
 		debugProcess.stderr.on("data", (data) => { });

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -227,7 +227,7 @@ export class ServerController {
 		}
 
 		log.info(`Launching game process using command: '${command}'`);
-		const debugProcess = subProcess("debug", command, { shell: true });
+		const debugProcess = subProcess("debug", command, { shell: true, detached: true });
 
 		debugProcess.stdout.on("data", (data) => { });
 		debugProcess.stderr.on("data", (data) => { });


### PR DESCRIPTION
This is a follow-up for https://github.com/godotengine/godot-vscode-plugin/pull/613. Both PRs need to be merged for this change to work.

**Issue:**

On Linux, when debugging session is initiated and then closed from VS Code, the game (i.e. the process being debugged) does not terminate.

**Steps to reproduce** are as you would expect:

1. Have a launch configuration for GDScript in VS Code properly set up.

2. Launch a project with F5.

3. Switch back to VS Code. Press Shift+F5 to close the debugging session.

4. The session closes but the project continues running.

**Cause:**

- Similar to https://github.com/godotengine/godot-vscode-plugin/pull/613, the debugger process is started with `shell: true` flag, which causes `child_process.spawn()` to first start a shell process which, in turn, starts the actual debugger. The returned PID is the shell's PID; the debugger runs under a different PID.

- When a debugging session terminates, the shell PID is killed. However, in Linux, child processes are allowed to persist when their parent is killed, so the debugger process survives.

- Contrary to https://github.com/godotengine/godot-vscode-plugin/pull/613, the debugger is not launched with `detached: true` ― which means it is also running under its own process group, and is effectively inaccessible to VS Code.

**Solution:**

Add `detached: true` to force both processes to share a process group. Rely on the change from https://github.com/godotengine/godot-vscode-plugin/pull/613 to kill the entire group rather than individual process(es).

**Other notes:**

Unlike https://github.com/godotengine/godot-vscode-plugin/pull/613, this change is not restricted to Linux, and may potentially cause unintended consequences on Windows and/or Mac OS. This shouldn't be the case assuming headless LSP works properly on these platforms, but more extensive testing is necessary.

In case it does cause problems on other platforms, the suggested fix is to set the flag depending on the platform, e.g. `detached: process.platform !== "win32" && process.platform !== "darwin"` or similar.

Additionally, Godot 3 integration may need to be tested separately since it uses a separate code path.