### PR TITLE
Fix poor documentation formatting of class titles and inheritance chain

### DIFF
--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -55,20 +55,10 @@ if (theme === vscode.ColorThemeKind.Dark) {
 	}`;
 }
 
-export function make_html_content(
-	webview: vscode.Webview,
-	symbol: GodotNativeSymbol,
-	target?: string
-): string {
-	const pagemapJsUri = webview.asWebviewUri(
-		get_extension_uri("media", "pagemap.js")
-	);
-	const prismCssUri = webview.asWebviewUri(
-		get_extension_uri("media", "prism.css")
-	);
-	const docsCssUri = webview.asWebviewUri(
-		get_extension_uri("media", "docs.css")
-	);
+export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSymbol, target?: string): string {
+	const pagemapJsUri = webview.asWebviewUri(get_extension_uri("media", "pagemap.js"));
+	const prismCssUri = webview.asWebviewUri(get_extension_uri("media", "prism.css"));
+	const docsCssUri = webview.asWebviewUri(get_extension_uri("media", "docs.css"));
 
 	let initialFocus = "";
 	if (target) {
@@ -79,7 +69,7 @@ export function make_html_content(
 		`;
 	}
 
-	return /*html*/ `<!DOCTYPE html>
+	return  /*html*/`<!DOCTYPE html>
 		<html>
 		<head>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -94,10 +84,10 @@ export function make_html_content(
 			</main>
 
 			<canvas id='map'></canvas>
-
+			
 			<script src="${pagemapJsUri}"></script>
 			<script>
-				pagemap(document.querySelector('#map'), ${options});
+				pagemap(document.querySelector('#map'), ${options});			
 				${initialFocus};
 
 				var vscode = acquireVsCodeApi();
@@ -138,7 +128,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		const ret_type = make_link(parts[2] || "void", undefined);
 		let args = (parts[1] || "").replace(
 			/\:\s([A-z0-9_]+)(\,\s*)?/g,
-			': <a href="" onclick="inspect(\'$1\')">$1</a>$2'
+			": <a href=\"\" onclick=\"inspect('$1')\">$1</a>$2"
 		);
 		args = args.replace(/\s=\s(.*?)[\,\)]/g, "");
 		return `${ret_type} ${with_class ? `${classlink}.` : ""}${element(
@@ -182,10 +172,9 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 				{
 					// const Control.FOCUS_ALL: FocusMode = 2
 					// const Control.NOTIFICATION_RESIZED = 40
-					const parts =
-						/\.([A-Za-z_0-9]+)(\:\s*)?([A-z0-9_\.]+)?\s*=\s*(.*)$/.exec(
-							s.detail
-						);
+					const parts = /\.([A-Za-z_0-9]+)(\:\s*)?([A-z0-9_\.]+)?\s*=\s*(.*)$/.exec(
+						s.detail
+					);
 					if (!parts) {
 						return;
 					}
@@ -215,12 +204,11 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 					}
 					const args = (parts[2] || "").replace(
 						/\:\s([A-z0-9_]+)(\,\s*)?/g,
-						': <a href="" onclick="inspect(\'$1\')">$1</a>$2'
+						": <a href=\"\" onclick=\"inspect('$1')\">$1</a>$2"
 					);
 					const title = element(
 						"p",
-						`${
-							with_class ? `signal ${with_class ? `${classlink}.` : ""}` : ""
+						`${with_class ? `signal ${with_class ? `${classlink}.` : ""}` : ""
 						}${s.name}( ${args} )`
 					);
 					const doc = element(
@@ -255,7 +243,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 	}
 
 	if (symbol.kind == SymbolKind.Class) {
-		let doc = element("h2", `Class: ${symbol.name}`);
+		let doc = element("h2", `${symbol.name}`);
 		if (symbol.class_info.inherits) {
 			const inherits = make_link(symbol.class_info.inherits, undefined);
 			doc += element("p", `Inherits: ${inherits}`);
@@ -269,7 +257,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 			doc += element("p", `Inherited by:${inherited}`);
 		}
 
-		doc += format_documentation(symbol.documentation, symbol.native_class);
+		doc += element("p", format_documentation(symbol.documentation, symbol.native_class));
 
 		let constants = "";
 		let signals = "";
@@ -348,9 +336,8 @@ function element<K extends keyof HTMLElementTagNameMap>(
 			props_str += ` ${key}="${props[key]}"`;
 		}
 	}
-	return `${indent || ""}<${tag} ${props_str}>${content}</${tag}>${
-		new_line ? "\n" : ""
-	}`;
+	return `${indent || ""}<${tag} ${props_str}>${content}</${tag}>${new_line ? "\n" : ""
+		}`;
 }
 
 function make_link(classname: string, symbol: string) {
@@ -370,7 +357,7 @@ function make_link(classname: string, symbol: string) {
 function make_codeblock(code: string, language: string) {
 	const lines = code.split("\n");
 	const indent = lines[0].match(/^\s*/)[0].length;
-	code = lines.map((line) => line.slice(indent)).join("\n");
+	code = lines.map(line => line.slice(indent)).join("\n");
 	return marked.parse(`\`\`\`${language}\n${code}\n\`\`\``);
 }
 
@@ -378,7 +365,7 @@ function format_documentation(bbcode: string, classname: string) {
 	let html = parser.parse(bbcode.trim());
 
 	html = html.replaceAll(/\[\/?codeblocks\](<br\/>)?/g, "");
-	html = html.replaceAll("&quot;", '"');
+	html = html.replaceAll("&quot;", "\"");
 
 	for (const match of html.matchAll(/\[codeblock].*?\[\/codeblock]/gs)) {
 		let block = match[0];
@@ -430,14 +417,12 @@ const GDScriptGrammar = {
 		lookbehind: true,
 	},
 	"string-interpolation": {
-		pattern:
-			/(?:f|rf|fr)(?:("""|''')[\s\S]+?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
+		pattern: /(?:f|rf|fr)(?:("""|''')[\s\S]+?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
 		greedy: true,
 		inside: {
 			interpolation: {
 				// "{" <expression> <optional "!s", "!r", or "!a"> <optional ":" format specifier> "}"
-				pattern:
-					/((?:^|[^{])(?:{{)*){(?!{)(?:[^{}]|{(?!{)(?:[^{}]|{(?!{)(?:[^{}])+})+})+}/,
+				pattern: /((?:^|[^{])(?:{{)*){(?!{)(?:[^{}]|{(?!{)(?:[^{}]|{(?!{)(?:[^{}])+})+})+}/,
 				lookbehind: true,
 				inside: {
 					"format-spec": {
@@ -479,13 +464,10 @@ const GDScriptGrammar = {
 			punctuation: /\./,
 		},
 	},
-	keyword:
-		/\b(?:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|master|puppet|slave|remotesync|mastersync|puppetsync)\b/,
-	builtin:
-		/\b(?:PI|TAU|NAN|INF|_|sin|cos|tan|sinh|cosh|tanh|asin|acos|atan|atan2|sqrt|fmod|fposmod|floor|ceil|round|abs|sign|pow|log|exp|is_nan|is_inf|ease|decimals|stepify|lerp|dectime|randomize|randi|randf|rand_range|seed|rand_seed|deg2rad|rad2deg|linear2db|db2linear|max|min|clamp|nearest_po2|weakref|funcref|convert|typeof|type_exists|char|str|print|printt|prints|printerr|printraw|var2str|str2var|var2bytes|bytes2var|range|load|inst2dict|dict2inst|hash|Color8|print_stack|instance_from_id|preload|yield|assert|Vector2|Vector3|Color|Rect2|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|AABB|String|Color|NodePath|RID|Object|Dictionary|Array|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray)\b/,
+	keyword: /\b(?:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|master|puppet|slave|remotesync|mastersync|puppetsync)\b/,
+	builtin: /\b(?:PI|TAU|NAN|INF|_|sin|cos|tan|sinh|cosh|tanh|asin|acos|atan|atan2|sqrt|fmod|fposmod|floor|ceil|round|abs|sign|pow|log|exp|is_nan|is_inf|ease|decimals|stepify|lerp|dectime|randomize|randi|randf|rand_range|seed|rand_seed|deg2rad|rad2deg|linear2db|db2linear|max|min|clamp|nearest_po2|weakref|funcref|convert|typeof|type_exists|char|str|print|printt|prints|printerr|printraw|var2str|str2var|var2bytes|bytes2var|range|load|inst2dict|dict2inst|hash|Color8|print_stack|instance_from_id|preload|yield|assert|Vector2|Vector3|Color|Rect2|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|AABB|String|Color|NodePath|RID|Object|Dictionary|Array|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray)\b/,
 	boolean: /\b(?:true|false)\b/,
-	number:
-		/(?:\b(?=\d)|\B(?=\.))(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
+	number: /(?:\b(?=\d)|\B(?=\.))(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
 	operator: /[-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]/,
 	punctuation: /[{}[\];(),.:]/,
 };

--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -243,7 +243,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 	}
 
 	if (symbol.kind == SymbolKind.Class) {
-		let doc = element("h2", `${symbol.name}`);
+		let doc = element("h2", `Class: ${symbol.name}`);
 		if (symbol.class_info.inherits) {
 			const inherits = make_link(symbol.class_info.inherits, undefined);
 			doc += element("p", `Inherits: ${inherits}`);

--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -55,10 +55,20 @@ if (theme === vscode.ColorThemeKind.Dark) {
 	}`;
 }
 
-export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSymbol, target?: string): string {
-	const pagemapJsUri = webview.asWebviewUri(get_extension_uri("media", "pagemap.js"));
-	const prismCssUri = webview.asWebviewUri(get_extension_uri("media", "prism.css"));
-	const docsCssUri = webview.asWebviewUri(get_extension_uri("media", "docs.css"));
+export function make_html_content(
+	webview: vscode.Webview,
+	symbol: GodotNativeSymbol,
+	target?: string
+): string {
+	const pagemapJsUri = webview.asWebviewUri(
+		get_extension_uri("media", "pagemap.js")
+	);
+	const prismCssUri = webview.asWebviewUri(
+		get_extension_uri("media", "prism.css")
+	);
+	const docsCssUri = webview.asWebviewUri(
+		get_extension_uri("media", "docs.css")
+	);
 
 	let initialFocus = "";
 	if (target) {
@@ -69,7 +79,7 @@ export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSy
 		`;
 	}
 
-	return  /*html*/`<!DOCTYPE html>
+	return /*html*/ `<!DOCTYPE html>
 		<html>
 		<head>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -84,10 +94,10 @@ export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSy
 			</main>
 
 			<canvas id='map'></canvas>
-			
+
 			<script src="${pagemapJsUri}"></script>
 			<script>
-				pagemap(document.querySelector('#map'), ${options});			
+				pagemap(document.querySelector('#map'), ${options});
 				${initialFocus};
 
 				var vscode = acquireVsCodeApi();
@@ -128,7 +138,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		const ret_type = make_link(parts[2] || "void", undefined);
 		let args = (parts[1] || "").replace(
 			/\:\s([A-z0-9_]+)(\,\s*)?/g,
-			": <a href=\"\" onclick=\"inspect('$1')\">$1</a>$2"
+			': <a href="" onclick="inspect(\'$1\')">$1</a>$2'
 		);
 		args = args.replace(/\s=\s(.*?)[\,\)]/g, "");
 		return `${ret_type} ${with_class ? `${classlink}.` : ""}${element(
@@ -172,9 +182,10 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 				{
 					// const Control.FOCUS_ALL: FocusMode = 2
 					// const Control.NOTIFICATION_RESIZED = 40
-					const parts = /\.([A-Za-z_0-9]+)(\:\s*)?([A-z0-9_\.]+)?\s*=\s*(.*)$/.exec(
-						s.detail
-					);
+					const parts =
+						/\.([A-Za-z_0-9]+)(\:\s*)?([A-z0-9_\.]+)?\s*=\s*(.*)$/.exec(
+							s.detail
+						);
 					if (!parts) {
 						return;
 					}
@@ -204,11 +215,12 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 					}
 					const args = (parts[2] || "").replace(
 						/\:\s([A-z0-9_]+)(\,\s*)?/g,
-						": <a href=\"\" onclick=\"inspect('$1')\">$1</a>$2"
+						': <a href="" onclick="inspect(\'$1\')">$1</a>$2'
 					);
 					const title = element(
 						"p",
-						`${with_class ? `signal ${with_class ? `${classlink}.` : ""}` : ""
+						`${
+							with_class ? `signal ${with_class ? `${classlink}.` : ""}` : ""
 						}${s.name}( ${args} )`
 					);
 					const doc = element(
@@ -243,22 +255,12 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 	}
 
 	if (symbol.kind == SymbolKind.Class) {
-		let doc = element("h2", `Native class ${symbol.name}`);
-		const parts = /extends\s+([A-z0-9]+)/.exec(symbol.detail);
-		let inherits = parts && parts.length > 1 ? parts[1] : "";
-		if (inherits) {
-			let inherits_chain = "";
-			let base_class = symbol.class_info[inherits];
-			while (base_class) {
-				inherits_chain += `${inherits_chain ? " >" : ""} ${make_link(
-					base_class.name,
-					undefined
-				)}`;
-				base_class = symbol.class_info[base_class.inherits];
-			}
-			inherits = `Inherits: ${inherits_chain}`;
-			doc += element("p", inherits);
+		let doc = element("h2", `${symbol.name}`);
+		if (symbol.class_info.inherits) {
+			const inherits = make_link(symbol.class_info.inherits, undefined);
+			doc += element("p", `Inherits: ${inherits}`);
 		}
+
 		if (symbol.class_info && symbol.class_info.extended_classes) {
 			let inherited = "";
 			for (const c of symbol.class_info.extended_classes) {
@@ -266,6 +268,8 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 			}
 			doc += element("p", `Inherited by:${inherited}`);
 		}
+
+		doc += format_documentation(symbol.documentation, symbol.native_class);
 
 		let constants = "";
 		let signals = "";
@@ -307,10 +311,6 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 			}
 		};
 
-		doc += element(
-			"p",
-			format_documentation(symbol.documentation, symbol.native_class)
-		);
 		add_group("Properties", properties_index);
 		add_group("Constants", constants);
 		add_group("Signals", signals);
@@ -348,8 +348,9 @@ function element<K extends keyof HTMLElementTagNameMap>(
 			props_str += ` ${key}="${props[key]}"`;
 		}
 	}
-	return `${indent || ""}<${tag} ${props_str}>${content}</${tag}>${new_line ? "\n" : ""
-		}`;
+	return `${indent || ""}<${tag} ${props_str}>${content}</${tag}>${
+		new_line ? "\n" : ""
+	}`;
 }
 
 function make_link(classname: string, symbol: string) {
@@ -369,7 +370,7 @@ function make_link(classname: string, symbol: string) {
 function make_codeblock(code: string, language: string) {
 	const lines = code.split("\n");
 	const indent = lines[0].match(/^\s*/)[0].length;
-	code = lines.map(line => line.slice(indent)).join("\n");
+	code = lines.map((line) => line.slice(indent)).join("\n");
 	return marked.parse(`\`\`\`${language}\n${code}\n\`\`\``);
 }
 
@@ -377,7 +378,7 @@ function format_documentation(bbcode: string, classname: string) {
 	let html = parser.parse(bbcode.trim());
 
 	html = html.replaceAll(/\[\/?codeblocks\](<br\/>)?/g, "");
-	html = html.replaceAll("&quot;", "\"");
+	html = html.replaceAll("&quot;", '"');
 
 	for (const match of html.matchAll(/\[codeblock].*?\[\/codeblock]/gs)) {
 		let block = match[0];
@@ -429,12 +430,14 @@ const GDScriptGrammar = {
 		lookbehind: true,
 	},
 	"string-interpolation": {
-		pattern: /(?:f|rf|fr)(?:("""|''')[\s\S]+?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
+		pattern:
+			/(?:f|rf|fr)(?:("""|''')[\s\S]+?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
 		greedy: true,
 		inside: {
 			interpolation: {
 				// "{" <expression> <optional "!s", "!r", or "!a"> <optional ":" format specifier> "}"
-				pattern: /((?:^|[^{])(?:{{)*){(?!{)(?:[^{}]|{(?!{)(?:[^{}]|{(?!{)(?:[^{}])+})+})+}/,
+				pattern:
+					/((?:^|[^{])(?:{{)*){(?!{)(?:[^{}]|{(?!{)(?:[^{}]|{(?!{)(?:[^{}])+})+})+}/,
 				lookbehind: true,
 				inside: {
 					"format-spec": {
@@ -476,10 +479,13 @@ const GDScriptGrammar = {
 			punctuation: /\./,
 		},
 	},
-	keyword: /\b(?:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|master|puppet|slave|remotesync|mastersync|puppetsync)\b/,
-	builtin: /\b(?:PI|TAU|NAN|INF|_|sin|cos|tan|sinh|cosh|tanh|asin|acos|atan|atan2|sqrt|fmod|fposmod|floor|ceil|round|abs|sign|pow|log|exp|is_nan|is_inf|ease|decimals|stepify|lerp|dectime|randomize|randi|randf|rand_range|seed|rand_seed|deg2rad|rad2deg|linear2db|db2linear|max|min|clamp|nearest_po2|weakref|funcref|convert|typeof|type_exists|char|str|print|printt|prints|printerr|printraw|var2str|str2var|var2bytes|bytes2var|range|load|inst2dict|dict2inst|hash|Color8|print_stack|instance_from_id|preload|yield|assert|Vector2|Vector3|Color|Rect2|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|AABB|String|Color|NodePath|RID|Object|Dictionary|Array|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray)\b/,
+	keyword:
+		/\b(?:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|master|puppet|slave|remotesync|mastersync|puppetsync)\b/,
+	builtin:
+		/\b(?:PI|TAU|NAN|INF|_|sin|cos|tan|sinh|cosh|tanh|asin|acos|atan|atan2|sqrt|fmod|fposmod|floor|ceil|round|abs|sign|pow|log|exp|is_nan|is_inf|ease|decimals|stepify|lerp|dectime|randomize|randi|randf|rand_range|seed|rand_seed|deg2rad|rad2deg|linear2db|db2linear|max|min|clamp|nearest_po2|weakref|funcref|convert|typeof|type_exists|char|str|print|printt|prints|printerr|printraw|var2str|str2var|var2bytes|bytes2var|range|load|inst2dict|dict2inst|hash|Color8|print_stack|instance_from_id|preload|yield|assert|Vector2|Vector3|Color|Rect2|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|AABB|String|Color|NodePath|RID|Object|Dictionary|Array|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray)\b/,
 	boolean: /\b(?:true|false)\b/,
-	number: /(?:\b(?=\d)|\B(?=\.))(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
+	number:
+		/(?:\b(?=\d)|\B(?=\.))(?:0[bo])?(?:(?:\d|0x[\da-f])[\da-f]*\.?\d*|\.\d+)(?:e[+-]?\d+)?j?\b/i,
 	operator: /[-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]/,
 	punctuation: /[{}[\];(),.:]/,
 };

--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -255,7 +255,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 	}
 
 	if (symbol.kind == SymbolKind.Class) {
-		let doc = element("h2", `${symbol.name}`);
+		let doc = element("h2", `Class: ${symbol.name}`);
 		if (symbol.class_info.inherits) {
 			const inherits = make_link(symbol.class_info.inherits, undefined);
 			doc += element("p", `Inherits: ${inherits}`);


### PR DESCRIPTION
It seems the extended inheritance chain previously being parsed is no longer available, which causes the "Inherits: " information to be empty. Inspecting the symbol information available, it seems there is no way to recover the inheritance chain without additional queries or modifying LSP response, so a quick fix to display the correct information that we do have is an incremental improvement.

**Before**
<img width="303" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/affcd56d-aabf-409b-be08-6e1541371959">

**After**
<img width="307" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/8a236b27-2078-4134-aca5-df608eb2f18c">
