### PR TITLE
Improve codeblock formatting in documentation

### DIFF
--- a/media/docs.css
+++ b/media/docs.css
@@ -20,10 +20,13 @@ pre:has(code) {
 	background-color: var(--vscode-textPreformat-background);
 	padding: 2.5em 1.5em 1em 1.5em;
 	border-radius: 8px;
+	overflow-x: auto;
 }
 
 pre code {
-	background-color: none !important;
+	background-color: transparent !important;
+	padding-left: 0px;
+	padding-right: 0px;
 }
 
 pre:has(code[class*="language-"])::before {

--- a/media/docs.css
+++ b/media/docs.css
@@ -22,6 +22,10 @@ pre:has(code) {
 	border-radius: 8px;
 }
 
+pre code {
+	background-color: none !important;
+}
+
 pre:has(code[class*="language-"])::before {
 	position: absolute;
 	top: 0;

--- a/media/docs.css
+++ b/media/docs.css
@@ -1,11 +1,3 @@
-.codeblock {
-	padding: 0.5em;
-	margin: .5em 0;
-	overflow: auto;
-	border-radius: 0.3em;
-	!background-color: #fdf6e3;
-}
-
 body {
 	margin-right: 200px;
 }
@@ -21,4 +13,28 @@ a {
 	width: 200px;
 	height: 100%;
 	z-index: 100;
+}
+
+pre:has(code) {
+	position: relative;
+	background-color: var(--vscode-textPreformat-background);
+	padding: 2.5em 1.5em 1em 1.5em;
+	border-radius: 8px;
+}
+
+pre:has(code[class*="language-"])::before {
+	position: absolute;
+	top: 0;
+	left: 0;
+	padding: 0.5em 1em;
+	color: var(--vscode-titlebar-activeForeground);
+	font-family: var(--vscode-font-family);
+}
+
+pre:has(code.language-gdscript)::before {
+	content: "GDScript";
+}
+
+pre:has(code.language-csharp)::before {
+	content: "C#";
 }


### PR DESCRIPTION
Improves codeblock highlighting by:

 -  Adding context to the codeblock detailing which language the following code is.
 -  Setting the `pre` block's background to match the default background for `code` blocks to give a consistent experience.
 -  Setting a border radius for the `pre` block double that of the `code` block's default (4px, which is hard-coded).

Works on class documentation blocks and `li` code blocks for properties/members/methods.

**Before**

<img width="1193" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/6cd276d0-71d8-4878-9d5d-0ffcec71a382">
<img width="968" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/9679e6a4-1ba4-4588-91da-6299c3845c7f">

**After**

<img width="1211" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/aad5662d-d1e5-40f7-9511-1362c5482710">
<img width="988" alt="image" src="https://github.com/godotengine/godot-vscode-plugin/assets/1476969/f9de0e3c-3ce6-44ef-81b1-f205a882b349">
