### PR TITLE
Fix project not found when `project.godot` file is excluded

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,7 +17,7 @@ export async function find_file(file: string): Promise<vscode.Uri | null> {
 		return vscode.Uri.file(file);
 	} else {
 		const fileName = path.basename(file);
-		const results = await vscode.workspace.findFiles("**/" + fileName);
+		const results = await vscode.workspace.findFiles("**/" + fileName, null);
 		if (results.length == 1) {
 			return results[0];
 		}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,13 +15,13 @@ export function is_debug_mode(): boolean {
 export async function find_file(file: string): Promise<vscode.Uri | null> {
 	if (fs.existsSync(file)) {
 		return vscode.Uri.file(file);
-	} else {
-		const fileName = path.basename(file);
-		const results = await vscode.workspace.findFiles("**/" + fileName, null);
-		if (results.length == 1) {
-			return results[0];
-		}
 	}
+	const fileName = path.basename(file);
+	const results = await vscode.workspace.findFiles(`**/${fileName}`, null);
+	if (results.length === 1) {
+		return results[0];
+	}
+	
 	return null;
 }
 
@@ -38,7 +38,7 @@ export async function get_free_port(): Promise<number> {
 export function make_docs_uri(path: string, fragment?: string) {
 	return vscode.Uri.from({
 		scheme: "gddoc",
-		path: path + ".gddoc",
+		path: `${path}.gddoc`,
 		fragment: fragment,
 	});
 }

--- a/src/utils/project_utils.ts
+++ b/src/utils/project_utils.ts
@@ -9,11 +9,11 @@ let projectFile: string | undefined = undefined;
 export async function get_project_dir(): Promise<string | undefined> {
 	let file = "";
 	if (vscode.workspace.workspaceFolders !== undefined) {
-		const files = await vscode.workspace.findFiles("**/project.godot");
+		const files = await vscode.workspace.findFiles("**/project.godot", null);
 
 		if (files.length === 0) {
 			return undefined;
-		} 
+		}
 		if (files.length === 1) {
 			file = files[0].fsPath;
 			if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
@@ -77,7 +77,7 @@ export function find_project_file(start: string, depth: number = 20) {
 	if (start === ".") {
 		if (fs.existsSync("project.godot") && fs.statSync("project.godot").isFile()) {
 			return "project.godot";
-		} 
+		}
 		return null;
 	}
 	const folder = path.dirname(start);


### PR DESCRIPTION
Fix a problem that when `project.godot` is excluded in VSCode, `get_project_version` function will always return `undefined`

**How to reproduce:**

1. Add `project.godot` into vscode settings
![image](https://github.com/godotengine/godot-vscode-plugin/assets/26314308/cef37df6-4f27-4f6e-b5ca-9499cfd83fe9)
2. Run **open workspace with Godot Editor**

There will be an error popup that the current workspace is not a godot project

**There is a simple fix:**

The `findFiles` api support taking a `null` value in the second parameter, then it will not take any exclusion from user config.

https://code.visualstudio.com/api/references/vscode-api
