### PR TITLE
Fix LSP connection attempts not resetting

### DIFF
--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -262,6 +262,7 @@ export class ClientConnectionManager {
 				break;
 			case ClientStatus.CONNECTED:
 				this.retry = false;
+				this.reconnectionAttempts = 0;
 				set_context("connectedToLSP", true);
 				this.status = ManagerStatus.CONNECTED;
 				if (!this.client.started) {

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -35,7 +35,7 @@ export class ClientConnectionManager {
 	private status: ManagerStatus = ManagerStatus.INITIALIZING;
 	private statusWidget: vscode.StatusBarItem = null;
 
-	private connectedVersion: string = "";
+	private connectedVersion = "";
 
 	constructor(private context: vscode.ExtensionContext) {
 		this.context = context;
@@ -125,11 +125,11 @@ export class ClientConnectionManager {
 		if (result.version[2] < minimumVersion) {
 			const message = `Cannot launch headless LSP: Headless LSP mode is only available on v${targetVersion} or newer, but the specified Godot executable is v${result.version}.`;
 			vscode.window.showErrorMessage(message, "Select Godot executable", "Open Settings", "Disable Headless LSP", "Ignore").then(item => {
-				if (item == "Select Godot executable") {
+				if (item === "Select Godot executable") {
 					select_godot_executable(settingName);
-				} else if (item == "Open Settings") {
+				} else if (item === "Open Settings") {
 					vscode.commands.executeCommand("workbench.action.openSettings", settingName);
-				} else if (item == "Disable Headless LSP") {
+				} else if (item === "Disable Headless LSP") {
 					set_configuration("lsp.headless", false);
 					prompt_for_reload();
 				}
@@ -192,7 +192,7 @@ export class ClientConnectionManager {
 				const message = `Connected to the GDScript language server at ${lspTarget}.`;
 
 				let options = ["Ok"];
-				if (this.target == TargetLSP.HEADLESS) {
+				if (this.target === TargetLSP.HEADLESS) {
 					options = ["Restart LSP", ...options];
 				}
 				vscode.window.showInformationMessage(message, ...options).then(item => {
@@ -271,7 +271,7 @@ export class ClientConnectionManager {
 			case ClientStatus.DISCONNECTED:
 				set_context("connectedToLSP", false);
 				if (this.retry) {
-					if (this.client.port != -1) {
+					if (this.client.port !== -1) {
 						this.status = ManagerStatus.INITIALIZING_LSP;
 					} else {
 						this.status = ManagerStatus.RETRYING;
@@ -317,15 +317,15 @@ export class ClientConnectionManager {
 		const message = `Couldn't connect to the GDScript language server at ${lspTarget}. Is the Godot editor or language server running?`;
 
 		let options = ["Retry", "Ignore"];
-		if (this.target == TargetLSP.EDITOR) {
+		if (this.target === TargetLSP.EDITOR) {
 			options = ["Open workspace with Godot Editor", ...options];
 		}
 
 		vscode.window.showErrorMessage(message, ...options).then(item => {
-			if (item == "Retry") {
+			if (item === "Retry") {
 				this.connect_to_language_server();
 			}
-			if (item == "Open workspace with Godot Editor") {
+			if (item === "Open workspace with Godot Editor") {
 				vscode.commands.executeCommand("godotTools.openEditor");
 				this.connect_to_language_server();
 			}

--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -21,7 +21,7 @@ export enum TargetLSP {
 const CUSTOM_MESSAGE = "gdscript_client/";
 
 export default class GDScriptLanguageClient extends LanguageClient {
-	public readonly io: MessageIO = (get_configuration("lsp.serverProtocol") == "ws") ? new WebSocketMessageIO() : new TCPMessageIO();
+	public readonly io: MessageIO = (get_configuration("lsp.serverProtocol") === "ws") ? new WebSocketMessageIO() : new TCPMessageIO();
 
 	private _status_changed_callbacks: ((v: ClientStatus) => void)[] = [];
 	private _initialize_request: Message = null;
@@ -29,18 +29,18 @@ export default class GDScriptLanguageClient extends LanguageClient {
 
 	public target: TargetLSP = TargetLSP.EDITOR;
 
-	public port: number = -1;
-	public lastPortTried: number = -1;
+	public port = -1;
+	public lastPortTried = -1;
 	public sentMessages = new Map();
-	public lastSymbolHovered: string = "";
+	public lastSymbolHovered = "";
 
-	private _started: boolean = false;
+	private _started = false;
 	public get started(): boolean { return this._started; }
 
 	private _status: ClientStatus;
 	public get status(): ClientStatus { return this._status; }
 	public set status(v: ClientStatus) {
-		if (this._status != v) {
+		if (this._status !== v) {
 			this._status = v;
 			for (const callback of this._status_changed_callbacks) {
 				callback(v);
@@ -49,7 +49,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 	}
 
 	public watch_status(callback: (v: ClientStatus) => void) {
-		if (this._status_changed_callbacks.indexOf(callback) == -1) {
+		if (this._status_changed_callbacks.indexOf(callback) === -1) {
 			this._status_changed_callbacks.push(callback);
 		}
 	}
@@ -95,7 +95,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 			port = this.port;
 		}
 
-		if (this.target == TargetLSP.EDITOR) {
+		if (this.target === TargetLSP.EDITOR) {
 			if (port === 6005 || port === 6008) {
 				port = 6005;
 			}
@@ -117,7 +117,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 	private on_send_message(message: RequestMessage) {
 		this.sentMessages.set(message.id, message);
 
-		if (message.method == "initialize") {
+		if (message.method === "initialize") {
 			this._initialize_request = message;
 		}
 	}
@@ -186,7 +186,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 		const contents = message["contents"];
 
 		let decl: string;
-		if (contents instanceof Array) {
+		if (Array.isArray(contents)) {
 			decl = contents[0];
 		} else {
 			decl = contents.value;
@@ -196,7 +196,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 		}
 		decl = decl.split("\n")[0].trim();
 
-		let match;
+		let match: RegExpMatchArray;
 		let result = undefined;
 		match = decl.match(/(?:func|const) (@?\w+)\.(\w+)/);
 		if (match) {
@@ -222,7 +222,7 @@ export default class GDScriptLanguageClient extends LanguageClient {
 	}
 
 	private on_disconnected() {
-		if (this.target == TargetLSP.EDITOR) {
+		if (this.target === TargetLSP.EDITOR) {
 			const host = get_configuration("lsp.serverHost");
 			let port = get_configuration("lsp.serverPort");
 


### PR DESCRIPTION
Should fix #636.

The internal count of connection attempts was incorrectly not being reset when a connection is actually established. This caused the connection retry to fail after several successful reconnections.