### PR TITLE
Prevent document links from accidentally being resolved to your entire document

### DIFF
--- a/src/providers/document_link.ts
+++ b/src/providers/document_link.ts
@@ -62,7 +62,7 @@ export class GDDocumentLinkProvider implements DocumentLinkProvider {
 				links.push(link);
 			}
 		}
-		for (const match of text.matchAll(/res:\/\/[^"^']*/g)) {
+		for (const match of text.matchAll(/res:\/\/([^"'\n]*)/g)) {
 			const r = this.create_range(document, match);
 			const uri = await convert_resource_path_to_uri(match[0]);
 			if (uri instanceof Uri) {


### PR DESCRIPTION
Fixes #621

The document link provider used a regex that could accidentally consume your entire document.

This fix makes the pattern end at a newline, so the most it could consume is the rest of the current line.

I would prefer to make this behavior more restricted, but I don't see a clean way to do that right now.