### PR TITLE
Fix relative godotPath values not resolving correctly

### DIFF
--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -8,7 +8,7 @@ import { RawObject } from "./variables/variants";
 import { GodotStackFrame, GodotStackVars } from "../debug_runtime";
 import { GodotDebugSession } from "./debug_session";
 import { parse_next_scene_node, split_buffers, build_sub_values } from "./helpers";
-import { get_configuration, get_free_port, createLogger, verify_godot_version, get_project_version } from "../../utils";
+import { get_configuration, get_free_port, createLogger, verify_godot_version, get_project_version, clean_godot_path } from "../../utils";
 import { prompt_for_godot_executable } from "../../utils/prompts";
 import { subProcess, killSubProcesses } from "../../utils/subspawn";
 import { LaunchRequestArguments, AttachRequestArguments, pinnedScene } from "../debugger";
@@ -107,7 +107,7 @@ export class ServerController {
 		if (args.editor_path) {
 			log.info("Using 'editor_path' variable from launch.json");
 
-			godotPath = args.editor_path.replace(/^"/, "").replace(/"$/, "");
+			godotPath = clean_godot_path(args.editor_path);
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "3");
@@ -134,7 +134,7 @@ export class ServerController {
 			log.info("Using 'editorPath.godot3' from settings");
 
 			const settingName = "editorPath.godot3";
-			godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
+			godotPath = clean_godot_path(get_configuration(settingName));
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "3");

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -8,7 +8,7 @@ import { RawObject } from "./variables/variants";
 import { GodotStackFrame, GodotVariable, GodotStackVars } from "../debug_runtime";
 import { GodotDebugSession } from "./debug_session";
 import { parse_next_scene_node, split_buffers, build_sub_values } from "./helpers";
-import { get_configuration, get_free_port, createLogger, verify_godot_version, get_project_version } from "../../utils";
+import { get_configuration, get_free_port, createLogger, verify_godot_version, get_project_version, clean_godot_path } from "../../utils";
 import { prompt_for_godot_executable } from "../../utils/prompts";
 import { subProcess, killSubProcesses } from "../../utils/subspawn";
 import { LaunchRequestArguments, AttachRequestArguments, pinnedScene } from "../debugger";
@@ -108,7 +108,7 @@ export class ServerController {
 		if (args.editor_path) {
 			log.info("Using 'editor_path' variable from launch.json");
 
-			godotPath = args.editor_path.replace(/^"/, "").replace(/"$/, "");
+			godotPath = clean_godot_path(args.editor_path);
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "4");
@@ -135,7 +135,7 @@ export class ServerController {
 			log.info("Using 'editorPath.godot4' from settings");
 
 			const settingName = "editorPath.godot4";
-			godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
+			godotPath = clean_godot_path(get_configuration(settingName));
 
 			log.info(`Verifying version of '${godotPath}'`);
 			result = verify_godot_version(godotPath, "4");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { attemptSettingsUpdate, get_extension_uri } from "./utils";
+import { attemptSettingsUpdate, get_extension_uri, clean_godot_path } from "./utils";
 import {
 	GDInlayHintsProvider,
 	GDHoverProvider,
@@ -82,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
 async function initial_setup() {
 	const projectVersion = await get_project_version();
 	const settingName = `editorPath.godot${projectVersion[0]}`;
-	const godotPath = get_configuration(settingName);
+	const godotPath = clean_godot_path(get_configuration(settingName));
 	const result = verify_godot_version(godotPath, projectVersion[0]);
 
 	switch (result.status) {
@@ -153,7 +153,7 @@ async function open_workspace_with_editor() {
 	const projectVersion = await get_project_version();
 
 	const settingName = `editorPath.godot${projectVersion[0]}`;
-	const godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
+	const godotPath = clean_godot_path(get_configuration(settingName));
 	const result = verify_godot_version(godotPath, projectVersion[0]);
 
 	switch (result.status) {
@@ -204,9 +204,7 @@ async function get_godot_path(): Promise<string|undefined> {
 		return undefined;
 	}
 	const settingName = `editorPath.godot${projectVersion[0]}`;
-	// Cleans up any surrounding quotes the user might put into the path.
-	const godotPath : string = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
-	return godotPath;
+	return clean_godot_path(get_configuration(settingName));
 }
 
 class GodotEditorTerminal implements vscode.Pseudoterminal {

--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -10,6 +10,7 @@ import {
 	set_configuration,
 	createLogger,
 	verify_godot_version,
+	clean_godot_path,
 } from "../utils";
 import { prompt_for_godot_executable, prompt_for_reload, select_godot_executable } from "../utils/prompts";
 import { subProcess, killSubProcesses } from "../utils/subspawn";
@@ -105,7 +106,7 @@ export class ClientConnectionManager {
 			targetVersion = "4.2";
 		}
 		const settingName = `editorPath.godot${projectVersion[0]}`;
-		const godotPath = get_configuration(settingName).replace(/^"/, "").replace(/"$/, "");
+		const godotPath = clean_godot_path(get_configuration(settingName));
 
 		const result = verify_godot_version(godotPath, projectVersion[0]);
 		switch (result.status) {


### PR DESCRIPTION
Should fix #654

Relative path values for `editorPath.godot3` and `editorPath.godot4` were failing to resolve properly. This PR should fix that behavior, plus standardize all the places the editorPath is being retrieved, so the same sanitization and path resolution is used everywhere.