### PR TITLE
Fix formatter addes spaces into '**'

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -185,7 +185,7 @@
 			"name": "keyword.operator.comparison.gdscript"
 		},
 		"arithmetic_operator": {
-			"match": "->|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\*|/|%|\\+|-|<<|>>|&|\\||\\^|~|!",
+			"match": "->|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\*\\*|\\*|/|%|\\+|-|<<|>>|&|\\||\\^|~|!",
 			"name": "keyword.operator.arithmetic.gdscript"
 		},
 		"assignment_operator": {


### PR DESCRIPTION
Fixes #602 

Simple but effective.  
It won't wrongly add spaces in this code anymore.
```gd
var value = 10 ** 5
```