### PR TITLE
Fix object id decoded as wrong signedness.

### DIFF
--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -377,9 +377,14 @@ export class ServerController {
 				break;
 			}
 			case "message:inspect_object": {
-				const id = BigInt(command.parameters[0]);
+				let id = BigInt(command.parameters[0]);
 				const className: string = command.parameters[1];
 				const properties: any[] = command.parameters[2];
+
+				// message:inspect_object returns the id as an unsigned 64 bit integer, but it is decoded as a signed 64 bit integer,
+				// thus we need to convert it to its equivalent unsigned value here.
+				if(id < 0)
+					id = id + BigInt(2) ** BigInt(64);
 
 				const rawObject = new RawObject(className);
 				properties.forEach((prop) => {

--- a/src/debugger/godot3/server_controller.ts
+++ b/src/debugger/godot3/server_controller.ts
@@ -383,8 +383,9 @@ export class ServerController {
 
 				// message:inspect_object returns the id as an unsigned 64 bit integer, but it is decoded as a signed 64 bit integer,
 				// thus we need to convert it to its equivalent unsigned value here.
-				if(id < 0)
+				if (id < 0) {
 					id = id + BigInt(2) ** BigInt(64);
+				}
 
 				const rawObject = new RawObject(className);
 				properties.forEach((prop) => {

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -376,9 +376,14 @@ export class ServerController {
 				break;
 			}
 			case "scene:inspect_object": {
-				const id = BigInt(command.parameters[0]);
+				let id = BigInt(command.parameters[0]);
 				const className: string = command.parameters[1];
 				const properties: any[] = command.parameters[2];
+
+				// message:inspect_object returns the id as an unsigned 64 bit integer, but it is decoded as a signed 64 bit integer,
+				// thus we need to convert it to its equivalent unsigned value here.
+				if(id < 0)
+					id = id + BigInt(2) ** BigInt(64);
 
 				const rawObject = new RawObject(className);
 				properties.forEach((prop) => {

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -382,8 +382,9 @@ export class ServerController {
 
 				// message:inspect_object returns the id as an unsigned 64 bit integer, but it is decoded as a signed 64 bit integer,
 				// thus we need to convert it to its equivalent unsigned value here.
-				if(id < 0)
+				if (id < 0) {
 					id = id + BigInt(2) ** BigInt(64);
+				}
 
 				const rawObject = new RawObject(className);
 				properties.forEach((prop) => {


### PR DESCRIPTION
This PR is the first commit of #662, cherry picked to preserve authorship.

Later commits in the PR break debugging, but this first commit is a good change and I'd like to merge it sooner than later.