### PR TITLE
fix format_documentation for `[code skip-lint]`

### DIFF
--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -362,6 +362,8 @@ function make_codeblock(code: string, language: string) {
 }
 
 function format_documentation(bbcode: string, classname: string) {
+	// ya-bbcode doesn't parse [code skip-lint] as a [code] tag
+	bbcode = bbcode.replaceAll("[code skip-lint]", "[code]");
 	let html = parser.parse(bbcode.trim());
 
 	html = html.replaceAll(/\[\/?codeblocks\](<br\/>)?/g, "");


### PR DESCRIPTION
ya-bbcode does not consider skip-lint to be an attribute, and it turns into the tag '[code skip-lint]' which won't match with the closing tag `[/code]`, leading to broken formatting.
I don't know if its valid bbcode or not, but Godot docs have it, for example the `Control` class documentation.