### PR TITLE
fix: No data when using typed arrays #699

### DIFF
--- a/src/debugger/godot4/variables/variant_decoder.ts
+++ b/src/debugger/godot4/variables/variant_decoder.ts
@@ -23,6 +23,7 @@ import {
 	Projection,
 	ENCODE_FLAG_64,
 	ENCODE_FLAG_OBJECT_AS_ID,
+	ENCODE_FIELD_TYPED_ARRAY_BUILTIN,
 	RID,
 	Callable,
 	Signal,
@@ -143,7 +144,11 @@ export class VariantDecoder {
 			case GDScriptTypes.DICTIONARY:
 				return this.decode_Dictionary(model);
 			case GDScriptTypes.ARRAY:
-				return this.decode_Array(model);
+				if (type & ENCODE_FIELD_TYPED_ARRAY_BUILTIN) {
+					return this.decode_Array_typed_builtin(model);
+				} else {
+					return this.decode_Array(model);
+				}
 			case GDScriptTypes.PACKED_BYTE_ARRAY:
 				return this.decode_PackedByteArray(model);
 			case GDScriptTypes.PACKED_INT32_ARRAY:
@@ -210,6 +215,21 @@ export class VariantDecoder {
 	private decode_Array(model: BufferModel) {
 		const output: Array<any> = [];
 
+		const count = this.decode_UInt32(model);
+
+		for (let i = 0; i < count; i++) {
+			const value = this.decode_variant(model);
+			output.push(value);
+		}
+
+		return output;
+	}
+
+	private decode_Array_typed_builtin(model: BufferModel) {
+		const output: Array<any> = [];
+
+		// TODO: Implement typed arrays
+		const _ = this.decode_UInt32(model); // Ignore array type
 		const count = this.decode_UInt32(model);
 
 		for (let i = 0; i < count; i++) {

--- a/src/debugger/godot4/variables/variants.ts
+++ b/src/debugger/godot4/variables/variants.ts
@@ -53,6 +53,7 @@ export enum GDScriptTypes {
 
 export const ENCODE_FLAG_64 = 1 << 16;
 export const ENCODE_FLAG_OBJECT_AS_ID = 1 << 16;
+export const ENCODE_FIELD_TYPED_ARRAY_BUILTIN = 1 << 16;
 
 export interface BufferModel {
 	buffer: Buffer;


### PR DESCRIPTION
Fixes #699 at least in some cases.

The current problem is that for some typed arrays their type is [added to the buffer](https://github.com/godotengine/godot/blob/77dcf97d82cbfe4e4615475fa52ca03da645dbd8/core/io/marshalls.cpp#L1801), but the extension doesn't handle it.

I'm not sure about my solution, but it fixes problem in my case.

Code to reproduce issue:
```python
class_name MainLevel extends Node3D

func _ready() -> void:
    Performance.add_custom_monitor("custom/the/test", _get_calculation_performance)

func _unhandled_input(event: InputEvent) -> void:
    if event.is_action_pressed("ui_cancel"):
        _register_monitor()

func _register_monitor() -> void:
    Performance.add_custom_monitor("custom/the/test_more", _get_calculation_performance)

func _get_calculation_performance() -> float:
    return 0
```