### PR TITLE
Standardize contributed language's extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,7 +381,7 @@
 					"gdscene"
 				],
 				"extensions": [
-					"tscn"
+					".tscn"
 				],
 				"configuration": "./configurations/gdresource.language-configuration.json"
 			},
@@ -392,11 +392,11 @@
 					"gdresource"
 				],
 				"extensions": [
-					"godot",
-					"tres",
-					"import",
-					"gdns",
-					"gdnlib"
+					".godot",
+					".tres",
+					".import",
+					".gdns",
+					".gdnlib"
 				],
 				"configuration": "./configurations/gdresource.language-configuration.json"
 			},


### PR DESCRIPTION
This change shouldn't have any actual effect, but I noticed that some file extensions were listed with a period and some weren't. Both styles appear to function the same, but the [language contribution point docs](https://code.visualstudio.com/api/references/contribution-points#contributes.languages) use a period, so I've standardized ours to be the same.