### PR TITLE
Fix typed arrays of scripts not being decoded properly

### DIFF
--- a/src/debugger/godot4/variables/variants.ts
+++ b/src/debugger/godot4/variables/variants.ts
@@ -54,7 +54,10 @@ export enum GDScriptTypes {
 
 export const ENCODE_FLAG_64 = 1 << 16;
 export const ENCODE_FLAG_OBJECT_AS_ID = 1 << 16;
-export const ENCODE_FLAG_TYPED_ARRAY = 1 << 16;
+export const ENCODE_FLAG_TYPED_ARRAY_MASK = 3 << 16;
+export const ENCODE_FLAG_TYPED_ARRAY_BUILTIN = 1 << 16;
+export const ENCODE_FLAG_TYPED_ARRAY_CLASS_NAME = 2 << 16;
+export const ENCODE_FLAG_TYPED_ARRAY_SCRIPT = 3 << 16;
 
 export interface BufferModel {
 	buffer: Buffer;


### PR DESCRIPTION
Related to #699.

This is likely the same issue as what's mentioned [here](https://github.com/godotengine/godot-vscode-plugin/issues/699#issuecomment-2372611126), which seems to stem from the fact that `decode_TypedArray` doesn't take into account all the forms that typed arrays can be encoded in.

Typed arrays can conditionally encode either a `uint32_t` as the type, if the array contains a built-in type, or a `String` if the array contains scripts of some kind, and `decode_TypedArray` currently only accounts for the former and not the latter.

This PR fixes this issue by incorporating not only `HEADER_DATA_FIELD_TYPED_ARRAY_BUILTIN`, but also `HEADER_DATA_FIELD_TYPED_ARRAY_CLASS_NAME` and `HEADER_DATA_FIELD_TYPED_ARRAY_SCRIPT`, as found [here](https://github.com/godotengine/godot/blob/4c4e67334412f73c9deba5e5d29afa8651418af2/core/io/marshalls.cpp#L73-L75).

Similar to what's already being done, this also just discards this new script name/path.