### PR TITLE
Update float syntax rules and formatting

### DIFF
--- a/src/formatter/snapshots/float_notation.gd
+++ b/src/formatter/snapshots/float_notation.gd
@@ -1,0 +1,25 @@
+# --- IN ---
+func test():
+	# The following floating-point notations are all valid:
+	print(is_equal_approx(123., 123))
+	print(is_equal_approx(.123, 0.123))
+	print(is_equal_approx(.123e4, 1230))
+	print(is_equal_approx(123.e4, 1.23e6))
+	print(is_equal_approx(.123e-1, 0.0123))
+	print(is_equal_approx(123.e-1, 12.3))
+
+	# Same as above, but with negative numbers.
+	print(is_equal_approx(-123., -123))
+	print(is_equal_approx(-.123, -0.123))
+	print(is_equal_approx(-.123e4, -1230))
+	print(is_equal_approx(-123.e4, -1.23e6))
+	print(is_equal_approx(-.123e-1, -0.0123))
+	print(is_equal_approx(-123.e-1, -12.3))
+
+	# Same as above, but with explicit positive numbers (which is redundant).
+	print(is_equal_approx(+123., +123))
+	print(is_equal_approx(+.123, +0.123))
+	print(is_equal_approx(+.123e4, +1230))
+	print(is_equal_approx(+123.e4, +1.23e6))
+	print(is_equal_approx(+.123e-1, +0.0123))
+	print(is_equal_approx(+123.e-1, +12.3))

--- a/src/formatter/snapshots/leave_strings_alone.gd
+++ b/src/formatter/snapshots/leave_strings_alone.gd
@@ -12,5 +12,6 @@ func dump() -> String:
 		preview_texture: %s,
 		explorer_layer: %s,
 		connections: %s,
+		test {test},
 	}
 	"""

--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -74,6 +74,10 @@ function parse_token(token: Token) {
 	if (token.scopes.includes("meta.function.parameters.gdscript")) {
 		token.param = true;
 	}
+	if (token.scopes[0].includes("constant.numeric")) {
+		token.type = "literal";
+		return;
+	}
 	if (token.value.match(/[A-Za-z_]\w+/)) {
 		token.identifier = true;
 	}
@@ -144,7 +148,7 @@ function between(tokens: Token[], current: number, options: FormatterOptions) {
 
 	if (nextToken.param) {
 		if (options.denseFunctionParameters) {
-			if (prev === "-") {
+			if (prev === "-" || prev === "+") {
 				if (tokens[current - 2]?.value === "=") return "";
 				if (["keyword", "symbol"].includes(tokens[current - 2]?.type)) {
 					return "";
@@ -181,8 +185,9 @@ function between(tokens: Token[], current: number, options: FormatterOptions) {
 	}
 	if (prev === "@") return "";
 
-	if (prev === "-") {
+	if (prev === "-" || prev === "+") {
 		if (nextToken.identifier) return " ";
+		if (next === "(") return " ";
 		if (current === 1) return "";
 		if (["keyword", "symbol"].includes(tokens[current - 2]?.type)) {
 			return "";
@@ -304,7 +309,7 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 		const tokens: Token[] = [];
 		for (const t of lineTokens.tokens) {
 			const token: Token = {
-				scopes: t.scopes,
+				scopes: [t.scopes.join(" "), ...t.scopes],
 				original: line.text.slice(t.startIndex, t.endIndex),
 				value: line.text.slice(t.startIndex, t.endIndex).trim(),
 			};

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -263,21 +263,16 @@
 					"name": "constant.numeric.integer.hexadecimal.gdscript"
 				},
 				{
-					"match": "[-]?([0-9][0-9_]+\\.[0-9_]*(e[\\-\\+]?[0-9_]+)?)",
+					"match": "\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?",
 					"name": "constant.numeric.float.gdscript"
 				},
 				{
-					"match": "[-]?(\\.[0-9][0-9_]*(e[\\-\\+]?[0-9_]+)?)",
+					"match": "([0-9][0-9_]*)?\\.[0-9_]*([eE][+-]?[0-9_]+)?",
 					"name": "constant.numeric.float.gdscript"
 				},
 				{
-					"match": "[-]?([0-9][0-9_]*e[\\-\\+]?\\[0-9_])",
+					"match": "[0-9][0-9_]*[eE][+-]?[0-9_]+",
 					"name": "constant.numeric.float.gdscript"
-				},
-				{
-					"name": "constant.numeric.float.gdscript",
-					"match": "(?x)\n  (?<! \\w)(?:\n    (?:\n      \\.[0-9](?: _?[0-9] )*\n      |\n      [0-9](?: _?[0-9] )* \\. [0-9](?: _?[0-9] )*\n      |\n      [0-9](?: _?[0-9] )* \\.\n    ) (?: [eE][+-]?[0-9](?: _?[0-9] )* )?\n    |\n    [0-9](?: _?[0-9] )* (?: [eE][+-]?[0-9](?: _?[0-9] )* )\n  )([jJ])?\\b\n",
-					"captures": { "1": { "name": "storage.type.imaginary.number.gdscript" } }
 				},
 				{
 					"match": "[-]?[0-9][0-9_]*",

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -430,7 +430,7 @@
 			]
 		},
 		"annotations": {
-			"match": "(@)(export|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|abstract|static_unload)\\b",
+			"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|abstract|static_unload)\\b",
 			"captures": {
 				"1": { "name": "entity.name.function.decorator.gdscript" },
 				"2": { "name": "entity.name.function.decorator.gdscript" }

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -245,7 +245,7 @@
 			"captures": { "1": { "name": "keyword.control.gdscript" } }
 		},
 		"keywords": {
-			"match": "\\b(?:class|class_name|is|onready|tool|static|export|as|void|enum|assert|breakpoint|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|trait|namespace)\\b",
+			"match": "\\b(?:class|class_name|abstract|is|onready|tool|static|export|as|void|enum|assert|breakpoint|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|trait|namespace)\\b",
 			"name": "keyword.language.gdscript"
 		},
 		"letter": {
@@ -430,7 +430,7 @@
 			]
 		},
 		"annotations": {
-			"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|abstract|static_unload)\\b",
+			"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|static_unload)\\b",
 			"captures": {
 				"1": { "name": "entity.name.function.decorator.gdscript" },
 				"2": { "name": "entity.name.function.decorator.gdscript" }


### PR DESCRIPTION
Per @AlfishSoftware's [feedback](https://github.com/godotengine/godot-vscode-plugin/pull/746#discussion_r1847281166) or #746, this PR removes the float literal rule I copied from the MagicPython grammar and (hopefully!) fixes the existing float rules.