### PR TITLE
Add debugger support for Typed Dictionaries

### DIFF
--- a/src/debugger/godot4/variables/variant_decoder.ts
+++ b/src/debugger/godot4/variables/variant_decoder.ts
@@ -277,8 +277,8 @@ export class VariantDecoder {
 			keyType = this.decode_ContainerTypeFlag(model, type, 16);
 			valueType = this.decode_ContainerTypeFlag(model, type, 18);
 
-			console.log("type:", (type >> 16) & 0b11, "keyType:", keyType);
-			console.log("type:", type >> 18, "valueType:", valueType);
+			// console.log("type:", (type >> 16) & 0b11, "keyType:", keyType);
+			// console.log("type:", type >> 18, "valueType:", valueType);
 		}
 		// TODO: the type information is currently discarded
 		// it needs to be decoded and then packed into the output somehow

--- a/src/debugger/godot4/variables/variant_decoder.ts
+++ b/src/debugger/godot4/variables/variant_decoder.ts
@@ -226,7 +226,7 @@ export class VariantDecoder {
 	}
 
 	private decode_Array(model: BufferModel, type: GDScriptTypes) {
-		const output: Array<any> = [];
+		const output = [];
 
 		let arrayType = null;
 		if (type & ENCODE_FLAG_TYPED_ARRAY_MASK) {
@@ -269,7 +269,7 @@ export class VariantDecoder {
 	}
 
 	private decode_Dictionary(model: BufferModel, type: GDScriptTypes) {
-		const output = new Map<any, any>();
+		const output = new Map();
 
 		let keyType = null;
 		let valueType = null;

--- a/src/debugger/godot4/variables/variants.ts
+++ b/src/debugger/godot4/variables/variants.ts
@@ -54,10 +54,14 @@ export enum GDScriptTypes {
 
 export const ENCODE_FLAG_64 = 1 << 16;
 export const ENCODE_FLAG_OBJECT_AS_ID = 1 << 16;
-export const ENCODE_FLAG_TYPED_ARRAY_MASK = 3 << 16;
-export const ENCODE_FLAG_TYPED_ARRAY_BUILTIN = 1 << 16;
-export const ENCODE_FLAG_TYPED_ARRAY_CLASS_NAME = 2 << 16;
-export const ENCODE_FLAG_TYPED_ARRAY_SCRIPT = 3 << 16;
+export const ENCODE_FLAG_TYPED_ARRAY_MASK = 0b11 << 16;
+export const ENCODE_FLAG_TYPED_DICT_MASK = 0b1111 << 16;
+
+export enum ContainerTypeFlags {
+	BUILTIN = 1,
+	CLASS_NAME = 2,
+	SCRIPT = 3,
+}
 
 export interface BufferModel {
 	buffer: Buffer;


### PR DESCRIPTION
Adding support for Typed Dictionaries is similar to Typed Arrays from #715. 

This is still ONLY protocol decoding support. Carrying the type information through to the debugger UI will require rewriting a lot of code.

@Calinou Do you know when `4.4-stable` is expected to release? I would like to have this published as `v2.4.0` BEFORE the new engine drops, instead of playing catch-up like usual.