### PR TITLE
Fixes for VSCode attached debugging and related improvements.

### DIFF
--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -106,7 +106,7 @@ export class GodotDebugger implements DebugAdapterDescriptorFactory, DebugConfig
 		log.info(`Project version identified as ${projectVersion}`);
 
 		if (projectVersion.startsWith("4")) {
-			this.session = new Godot4DebugSession();
+			this.session = new Godot4DebugSession(projectVersion);
 		} else {
 			this.session = new Godot3DebugSession();
 		}

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -41,11 +41,13 @@ export class GodotDebugSession extends LoggingDebugSession {
 	private mode: "launch" | "attach" | "" = "";
 	public inspect_callbacks: Map<bigint, (class_name: string, variable: GodotVariable) => void> = new Map();
 
-	public constructor() {
+	public constructor(projectVersion : string) {
 		super();
 
 		this.setDebuggerLinesStartAt1(false);
 		this.setDebuggerColumnsStartAt1(false);
+
+		this.controller.setProjectVersion(projectVersion);
 	}
 
 	public dispose() {
@@ -100,6 +102,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 
 		this.mode = "attach";
 
+		this.debug_data.projectPath = args.project;
 		this.exception = false;
 		await this.controller.attach(args);
 

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -47,9 +47,19 @@ export class ServerController {
 	private steppingOut = false;
 	private didFirstOutput = false;
 	private partialStackVars = new GodotStackVars();
-	private connectedVersion = "";
+	private projectVersionMajor: number;
+	private projectVersionMinor : number;
+	private projectVersionPoint : number;
+
 
 	public constructor(public session: GodotDebugSession) {}
+
+	public setProjectVersion(projectVersion: string) {
+		const versionParts = projectVersion.split('.').map(Number);
+		this.projectVersionMajor = versionParts[0] || 0;
+		this.projectVersionMinor = versionParts[1] || 0;
+		this.projectVersionPoint = versionParts[2] || 0;
+	}
 
 	public break() {
 		this.send_command("break");
@@ -168,7 +178,7 @@ export class ServerController {
 			}
 		}
 
-		this.connectedVersion = result.version;
+		this.setProjectVersion(result.version);
 
 		let command = `"${godotPath}" --path "${args.project}"`;
 		const address = args.address.replace("tcp://", "");
@@ -345,7 +355,7 @@ export class ServerController {
 		const command = new Command();
 		let i = 0;
 		command.command = dataset[i++];
-		if (this.connectedVersion[2] >= "2") {
+		if (this.projectVersionMinor >= 2) {
 			command.threadId = dataset[i++];
 		}
 		command.parameters = dataset[i++];
@@ -610,7 +620,7 @@ export class ServerController {
 
 	private send_command(command: string, parameters?: any[]) {
 		const commandArray: any[] = [command];
-		if (this.connectedVersion[2] >= "2") {
+		if (this.projectVersionMinor >= 2) {
 			commandArray.push(this.threadId);
 		}
 		commandArray.push(parameters ?? []);


### PR DESCRIPTION
'launch' and 'attach' modes are working with these changes. The root problems were related to the version of the attached project not being detected properly and file paths not being correctly calculated when attached. The networking code that had version-dependent behavior is now a bit more robust and won't break if minor versions were to ever exceed 1 digit. When using 'attach' mode, the version info wasn't available at all, causing most (all?) network messages to be ignored.

Tested with attach and launch modes, and with a built vsix. 