### PR TITLE
Add setting to enable/disable documentation minimap

### DIFF
--- a/media/docs.css
+++ b/media/docs.css
@@ -1,7 +1,3 @@
-body {
-	margin-right: 200px;
-}
-
 a {
 	text-decoration: none;
 }

--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
 					"maximum": 200,
 					"description": "Scale factor (%) to apply to the Godot documentation viewer."
 				},
+				"godotTools.documentation.displayMinimap":{
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to display the minimap for the Godot documentation viewer."
+				},
 				"godotTools.editorPath.godot3": {
 					"type": "string",
 					"default": "godot3",

--- a/src/providers/documentation.ts
+++ b/src/providers/documentation.ts
@@ -114,8 +114,17 @@ export class GDDocumentationProvider implements CustomReadonlyEditorProvider {
 		}
 
 		const scaleFactor = get_configuration("documentation.pageScale");
-
 		panel.webview.html = this.htmlDb.get(className).replaceAll("scaleFactor", scaleFactor);
+
+		const displayMinimap = get_configuration("documentation.displayMinimap");
+		if (displayMinimap) {
+			panel.webview.html = this.htmlDb.get(className).replace("displayMinimap", "initial;");
+			panel.webview.html = this.htmlDb.get(className).replace("bodyMargin", "200px;");
+		} else {
+			panel.webview.html = this.htmlDb.get(className).replace("bodyMargin", "0px;");
+			panel.webview.html = this.htmlDb.get(className).replace("displayMinimap", "none;");
+		}
+
 		panel.iconPath = get_extension_uri("resources/godot_icon.svg");
 		panel.webview.onDidReceiveMessage((msg) => {
 			if (msg.type === "INSPECT_NATIVE_SYMBOL") {

--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -78,12 +78,12 @@ export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSy
 
 			<title>${symbol.name}</title>
 		</head>
-		<body style="line-height: scaleFactor%; font-size: scaleFactor%;">
+		<body style="line-height: scaleFactor%; font-size: scaleFactor%; margin-right: bodyMargin">
 			<main>
 				${make_symbol_document(symbol)}
 			</main>
 
-			<canvas id='minimap'></canvas>
+			<canvas id='minimap' style="display: displayMinimap"></canvas>
 			
 			<script src="${pagemapJsUri}"></script>
 			<script>


### PR DESCRIPTION
This adds an option in extension settings to enable/disable documentation minimap. The minimap will be enabled by default.

![image](https://github.com/user-attachments/assets/c78d4ca7-2edd-45e2-beb6-f0ed9af96c42)

Enabled
![image](https://github.com/user-attachments/assets/823a4a3a-d45d-404b-b019-9e6a94ebb1c6)

Disabled
![image](https://github.com/user-attachments/assets/d4823fc3-4e5e-406e-9368-a6e3c18efdb8)
