### PR TITLE
Implement Godot-in-the-loop test suite and fix debugger errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
           Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot43"
-          $env:Path+=";C:\Godot43"
-          "C:\Godot\Godot_v4.3-stable_win64.exe %*" | Out-File -Encoding ascii -FilePath "C:\Godot43\godot.cmd"
-
+          "C:\Godot\Godot_v4.3-stable_win64.exe %*" | Out-File -Encoding ascii -FilePath ([Environment]::SystemDirectory+"\godot.cmd")
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm install
 
       - name: Godot init project
-        run: godot --import test_projects/test-dap-project-godot4/project.godot --rendering-driver opengl3
+        run: godot --import test_projects/test-dap-project-godot4/project.godot --headless
 
       - name: Run headless test
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
           Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot43"
-          "C:\Godot\Godot_v4.3-stable_win64.exe %*" | Out-File -Encoding ascii -FilePath ([Environment]::SystemDirectory+"\godot.cmd")
+          "C:\Godot43\Godot_v4.3-stable_win64.exe %*" | Out-File -Encoding ascii -FilePath ([Environment]::SystemDirectory+"\godot.cmd")
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Godot (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          wget https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_linux.x86_64.zip
+          wget https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_linux.x86_64.zip
           unzip Godot_v4.3-stable_linux.x86_64.zip
           sudo mv Godot_v4.3-stable_linux.x86_64 /usr/local/bin/godot
           chmod +x /usr/local/bin/godot
@@ -28,16 +28,17 @@ jobs:
       - name: Install Godot (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          curl -L -o Godot.zip https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_macos.universal.zip
+          curl -L -o Godot.zip https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_macos.universal.zip
           unzip Godot.zip
           sudo mv Godot.app /Applications/Godot.app
 
       - name: Install Godot (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          Invoke-WebRequest -Uri "https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
+          Invoke-WebRequest -Uri "https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
           Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot"
           echo "C:\Godot" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           Invoke-WebRequest -Uri "https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
-          Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot"
-          echo "C:\Godot" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot43"
+          $env:Path+=";C:\Godot43"
+          "C:\Godot\Godot_v4.3-stable_win64.exe %*" | Out-File -Encoding ascii -FilePath "C:\Godot43\godot.cmd"
 
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [macos-latest]
         # os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm install
 
       - name: Godot init project
-        run: godot --import test_projects/test-dap-project-godot4/project.godot
+        run: godot --import test_projects/test-dap-project-godot4/project.godot --rendering-driver opengl3
 
       - name: Run headless test
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Install Godot
+        run: |
+          wget https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_linux.x86_64.zip
+          unzip Godot_v4.3-stable_linux.x86_64.zip
+          sudo mv Godot_v4.3-stable_linux.x86_64 /usr/local/bin/godot
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
         run: npm install
 
       - name: Godot init project
-        run: godot --import test_projects/test-dap-project-godot4/project.godot --headless
+        run: godot --import test_projects/test-dap-project-godot4/project.godot
+        # run: godot --import test_projects/test-dap-project-godot4/project.godot --headless # that works
 
       - name: Run headless test
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,28 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Install Godot (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          wget https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_linux.x86_64.zip
+          unzip Godot_v4.3-stable_linux.x86_64.zip
+          sudo mv Godot_v4.3-stable_linux.x86_64 /usr/local/bin/godot
+          chmod +x /usr/local/bin/godot
+
+      - name: Install Godot (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl -L -o Godot.zip https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_macos.universal.zip
+          unzip Godot.zip
+          sudo mv Godot.app /Applications/Godot.app
+
+      - name: Install Godot (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Invoke-WebRequest -Uri "https://downloads.tuxfamily.org/godotengine/4.3/Godot_v4.3-stable_win64.exe.zip" -OutFile "Godot.zip"
+          Expand-Archive -Path "Godot.zip" -DestinationPath "C:\Godot"
+          echo "C:\Godot" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Install dependencies
         run: npm install
 
@@ -37,12 +59,6 @@ jobs:
         uses: actions/setup-node@v4.2.0
         with:
           node-version: 16.x
-
-      - name: Install Godot
-        run: |
-          wget https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_linux.x86_64.zip
-          unzip Godot_v4.3-stable_linux.x86_64.zip
-          sudo mv Godot_v4.3-stable_linux.x86_64 /usr/local/bin/godot
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install and setup Wayland (weston)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y weston xvfb
+          Xvfb :99 -screen 0 1024x768x16 &
+          export DISPLAY=:99
+          weston --backend=headless-backend.so &
+
       - name: Godot init project
         run: godot --import test_projects/test-dap-project-godot4/project.godot
         # run: godot --import test_projects/test-dap-project-godot4/project.godot --headless # that works

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -31,6 +32,7 @@ jobs:
           curl -L -o Godot.zip https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_macos.universal.zip
           unzip Godot.zip
           sudo mv Godot.app /Applications/Godot.app
+          sudo ln -s /Applications/Godot.app/Contents/MacOS/Godot /usr/local/bin/godot
 
       - name: Install Godot (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Install and setup Wayland (weston)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y weston xvfb
-          Xvfb :99 -screen 0 1024x768x16 &
-          export DISPLAY=:99
-          weston --backend=headless-backend.so &
-
       - name: Godot init project
-        run: godot --import test_projects/test-dap-project-godot4/project.godot
-        # run: godot --import test_projects/test-dap-project-godot4/project.godot --headless # that works
+        run: godot --import test_projects/test-dap-project-godot4/project.godot --headless
 
       - name: Run headless test
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Godot init project
+        run: godot --import test_projects/test-dap-project-godot4/project.godot
+
       - name: Run headless test
         uses: coactions/setup-xvfb@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [macos-latest]
-        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [macos-latest]
-        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .vscode-test
 workspace.code-workspace
 .history
+.godot
+*.tmp

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -5,5 +5,7 @@ module.exports = defineConfig(
 		// version: '1.84.0',
 		label: 'unitTests',
 		files: 'out/**/*.test.js',
+		launchArgs: ['--disable-extensions'],
+		workspaceFolder: './test_projects/test-dap-project-godot4',
 	}
 );

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-vscode.extension-test-runner"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+		
 		{
 			"name": "Run Extension",
 			"type": "extensionHost",
@@ -22,7 +23,7 @@
 			],
 			"preLaunchTask": "npm: watch",
 			"env": {
-				"VSCODE_DEBUG_MODE": true
+				"VSCODE_DEBUG_MODE": "true"
 			}
 		},
 		{
@@ -33,7 +34,7 @@
 			"args": [
 				"--profile=temp",
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"${workspaceFolder}/workspace.code-workspace"
+				"${workspaceFolder}/test_projects/test-dap-project-godot4"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
@@ -44,7 +45,7 @@
 			],
 			"preLaunchTask": "npm: watch",
 			"env": {
-				"VSCODE_DEBUG_MODE": true
+				"VSCODE_DEBUG_MODE": "true"
 			}
 		},
 	]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
-				"@vscode/debugadapter": "^1.64.0",
-				"@vscode/debugprotocol": "^1.64.0",
+				"@vscode/debugadapter": "^1.68.0",
+				"@vscode/debugprotocol": "^1.68.0",
 				"await-notify": "^1.0.1",
 				"global": "^4.4.0",
 				"marked": "^4.0.11",
@@ -29,7 +29,7 @@
 				"@types/mocha": "^10.0.6",
 				"@types/node": "^18.15.0",
 				"@types/prismjs": "^1.16.8",
-				"@types/vscode": "^1.80.0",
+				"@types/vscode": "^1.96.0",
 				"@types/ws": "^8.5.4",
 				"@typescript-eslint/eslint-plugin": "^5.57.1",
 				"@typescript-eslint/eslint-plugin-tslint": "^5.57.1",
@@ -38,6 +38,7 @@
 				"@vscode/test-electron": "^2.3.8",
 				"@vscode/vsce": "^2.29.0",
 				"chai": "^4.3.10",
+				"chai-subset": "^1.6.0",
 				"esbuild": "^0.17.15",
 				"eslint": "^8.37.0",
 				"mocha": "^10.2.0",
@@ -1104,9 +1105,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.82.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-			"integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+			"version": "1.96.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+			"integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -1414,20 +1415,20 @@
 			}
 		},
 		"node_modules/@vscode/debugadapter": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.64.0.tgz",
-			"integrity": "sha512-XygE985qmNCzJExDnam4bErK6FG9Ck8S5TRPDNESwkt7i3OXqw5a3vYb7Dteyhz9YMEf7hwhFoT46Mjc45nJUg==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
 			"dependencies": {
-				"@vscode/debugprotocol": "1.64.0"
+				"@vscode/debugprotocol": "1.68.0"
 			},
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/@vscode/debugprotocol": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.64.0.tgz",
-			"integrity": "sha512-Zhf3KvB+J04M4HPE2yCvEILGVtPixXUQMLBvx4QcAtjhc5lnwlZbbt80LCsZO2B+2BH8RMgVXk3QQ5DEzEne2Q=="
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
 		},
 		"node_modules/@vscode/test-cli": {
 			"version": "0.0.4",
@@ -1892,9 +1893,9 @@
 			}
 		},
 		"node_modules/ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -2192,9 +2193,9 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "4.3.10",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+			"integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
@@ -2203,8 +2204,17 @@
 				"get-func-name": "^2.0.2",
 				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.8"
+				"type-detect": "^4.1.0"
 			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chai-subset": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
+			"integrity": "sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2498,12 +2508,12 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
 			"dev": true,
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -4466,32 +4476,31 @@
 			"optional": true
 		},
 		"node_modules/mocha": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+			"integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
 			"dev": true,
 			"dependencies": {
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.3",
-				"debug": "4.3.4",
-				"diff": "5.0.0",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.2.0",
-				"he": "1.2.0",
-				"js-yaml": "4.1.0",
-				"log-symbols": "4.1.0",
-				"minimatch": "5.0.1",
-				"ms": "2.1.3",
-				"nanoid": "3.3.3",
-				"serialize-javascript": "6.0.0",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "8.1.1",
-				"workerpool": "6.2.1",
-				"yargs": "16.2.0",
-				"yargs-parser": "20.2.4",
-				"yargs-unparser": "2.0.0"
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
 			},
 			"bin": {
 				"_mocha": "bin/_mocha",
@@ -4499,10 +4508,6 @@
 			},
 			"engines": {
 				"node": ">= 14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mochajs"
 			}
 		},
 		"node_modules/mocha/node_modules/argparse": {
@@ -4521,9 +4526,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
@@ -4539,6 +4544,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mocha/node_modules/has-flag": {
@@ -4563,9 +4588,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -4573,12 +4598,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/mocha/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
 		},
 		"node_modules/mocha/node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -4608,9 +4627,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
 		},
 		"node_modules/mute-stream": {
@@ -4618,18 +4637,6 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
-		},
-		"node_modules/nanoid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-			"integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-			"dev": true,
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
 		},
 		"node_modules/napi-build-utils": {
 			"version": "1.0.2",
@@ -5247,9 +5254,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
@@ -5635,9 +5642,9 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
@@ -5774,9 +5781,9 @@
 			}
 		},
 		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -5951,9 +5958,9 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-			"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
 			"dev": true
 		},
 		"node_modules/wrap-ansi": {
@@ -6222,9 +6229,9 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 				"typescript": "^5.2.2"
 			},
 			"engines": {
-				"vscode": "^1.80.0"
+				"vscode": "^1.96.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.11",
+				"@types/chai-subset": "^1.3.5",
 				"@types/marked": "^4.0.8",
 				"@types/mocha": "^10.0.6",
 				"@types/node": "^18.15.0",
@@ -1067,6 +1068,15 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
 			"integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
 			"dev": true
+		},
+		"node_modules/@types/chai-subset": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.5.tgz",
+			"integrity": "sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==",
+			"dev": true,
+			"dependencies": {
+				"@types/chai": "*"
+			}
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.13",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"author": "The Godot Engine community",
 	"publisher": "geequlim",
 	"engines": {
-		"vscode": "^1.80.0"
+		"vscode": "^1.96.0"
 	},
 	"categories": [
 		"Programming Languages",

--- a/package.json
+++ b/package.json
@@ -866,6 +866,7 @@
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.11",
+		"@types/chai-subset": "^1.3.5",
 		"@types/marked": "^4.0.8",
 		"@types/mocha": "^10.0.6",
 		"@types/node": "^18.15.0",

--- a/package.json
+++ b/package.json
@@ -870,7 +870,7 @@
 		"@types/mocha": "^10.0.6",
 		"@types/node": "^18.15.0",
 		"@types/prismjs": "^1.16.8",
-		"@types/vscode": "^1.80.0",
+		"@types/vscode": "^1.96.0",
 		"@types/ws": "^8.5.4",
 		"@typescript-eslint/eslint-plugin": "^5.57.1",
 		"@typescript-eslint/eslint-plugin-tslint": "^5.57.1",
@@ -879,6 +879,7 @@
 		"@vscode/test-electron": "^2.3.8",
 		"@vscode/vsce": "^2.29.0",
 		"chai": "^4.3.10",
+		"chai-subset": "^1.6.0",
 		"esbuild": "^0.17.15",
 		"eslint": "^8.37.0",
 		"mocha": "^10.2.0",
@@ -888,8 +889,8 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"@vscode/debugadapter": "^1.64.0",
-		"@vscode/debugprotocol": "^1.64.0",
+		"@vscode/debugadapter": "^1.68.0",
+		"@vscode/debugprotocol": "^1.68.0",
 		"await-notify": "^1.0.1",
 		"global": "^4.4.0",
 		"marked": "^4.0.11",

--- a/src/debugger/godot3/debug_session.ts
+++ b/src/debugger/godot3/debug_session.ts
@@ -25,7 +25,6 @@ interface Variable {
 	variable: GodotVariable;
 	index: number;
 	object_id: number;
-	error: string;
 }
 
 export class GodotDebugSession extends LoggingDebugSession {
@@ -404,7 +403,6 @@ export class GodotDebugSession extends LoggingDebugSession {
 			variable: null,
 			index: null,
 			object_id: null,
-			error: null,
 		};
 
 		if (!root) {

--- a/src/debugger/godot3/debug_session.ts
+++ b/src/debugger/godot3/debug_session.ts
@@ -126,17 +126,16 @@ export class GodotDebugSession extends LoggingDebugSession {
 		await debug.activeDebugSession.customRequest("scopes", { frameId: 0 });
 
 		if (this.all_scopes) {
-			const variable = this.get_variable(args.expression, null, null, null);
-
-			if (variable.error == null) {
+			try {
+				const variable = this.get_variable(args.expression, null, null, null);
 				const parsed_variable = parse_variable(variable.variable);
 				response.body = {
 					result: parsed_variable.value,
 					variablesReference: !is_variable_built_in_type(variable.variable) ? variable.index : 0,
 				};
-			} else {
+			} catch (error) {
 				response.success = false;
-				response.message = variable.error;
+				response.message = error.toString();
 			}
 		}
 
@@ -489,8 +488,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			(x) => x.sanitized.name === propertyName && x.sanitized.scope_path === path,
 		)?.real;
 		if (!result.variable) {
-			result.error = `Could not find: ${propertyName}`;
-			return result;
+			throw new Error(`Could not find: ${propertyName}`);
 		}
 
 		if (root.value.entries) {

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -25,7 +25,6 @@ interface Variable {
 	variable: GodotVariable;
 	index: number;
 	object_id: number;
-	error: string;
 }
 
 export class GodotDebugSession extends LoggingDebugSession {
@@ -404,7 +403,6 @@ export class GodotDebugSession extends LoggingDebugSession {
 			variable: null,
 			index: null,
 			object_id: null,
-			error: null,
 		};
 
 		if (!root) {

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -369,7 +369,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 				continue;
 			}
 			const old = this.all_scopes.splice(index, 1);
-			 // GodotVariable instance will be different for different variables, even if the referenced object id is the same:
+			// GodotVariable instance will be different for different variables, even if the referenced object id is the same:
 			const replacement = {value: rawObject, sub_values: sub_values } as GodotVariable;
 			replacement.name = old[0].name;
 			replacement.scope_path = old[0].scope_path;

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -126,17 +126,16 @@ export class GodotDebugSession extends LoggingDebugSession {
 		await debug.activeDebugSession.customRequest("scopes", { frameId: 0 });
 
 		if (this.all_scopes) {
-			const variable = this.get_variable(args.expression, null, null, null);
-
-			if (variable.error == null) {
+			try {
+				const variable = this.get_variable(args.expression, null, null, null);
 				const parsed_variable = parse_variable(variable.variable);
 				response.body = {
 					result: parsed_variable.value,
 					variablesReference: !is_variable_built_in_type(variable.variable) ? variable.index : 0,
 				};
-			} else {
+			} catch (error) {
 				response.success = false;
-				response.message = variable.error;
+				response.message = error.toString();
 			}
 		}
 
@@ -489,8 +488,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			(x) => x.sanitized.name === propertyName && x.sanitized.scope_path === path,
 		)?.real;
 		if (!result.variable) {
-			result.error = `Could not find: ${propertyName}`;
-			return result;
+			throw new Error(`Could not find: ${propertyName}`);
 		}
 
 		if (root.value.entries) {

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -370,10 +370,10 @@ export class GodotDebugSession extends LoggingDebugSession {
 			}
 			const old = this.all_scopes.splice(index, 1);
 			 // GodotVariable instance will be different for different variables, even if the referenced object id is the same:
-			const clonedReplacement = {value: rawObject, sub_values: sub_values } as GodotVariable;
-			clonedReplacement.name = old[0].name;
-			clonedReplacement.scope_path = old[0].scope_path;
-			this.append_variable(clonedReplacement, index);
+			const replacement = {value: rawObject, sub_values: sub_values } as GodotVariable;
+			replacement.name = old[0].name;
+			replacement.scope_path = old[0].scope_path;
+			this.append_variable(replacement, index);
 		}
 
 		const ongoing_inspections_index = this.ongoing_inspections.findIndex((va_id) => va_id === id);

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -55,6 +55,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 		response: DebugProtocol.InitializeResponse,
 		args: DebugProtocol.InitializeRequestArguments,
 	) {
+		log.info("initializeRequest", args);
 		response.body = response.body || {};
 
 		response.body.supportsConfigurationDoneRequest = true;
@@ -83,6 +84,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
+		log.info("launchRequest", args);
 		await this.configuration_done.wait(1000);
 
 		this.mode = "launch";
@@ -95,6 +97,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments) {
+		log.info("attachRequest", args);
 		await this.configuration_done.wait(1000);
 
 		this.mode = "attach";
@@ -109,11 +112,13 @@ export class GodotDebugSession extends LoggingDebugSession {
 		response: DebugProtocol.ConfigurationDoneResponse,
 		args: DebugProtocol.ConfigurationDoneArguments,
 	) {
+		log.info("configurationDoneRequest", args);
 		this.configuration_done.notify();
 		this.sendResponse(response);
 	}
 
 	protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) {
+		log.info("continueRequest", args);
 		if (!this.exception) {
 			response.body = { allThreadsContinued: true };
 			this.controller.continue();
@@ -122,6 +127,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) {
+		log.info("evaluateRequest", args);
 		await debug.activeDebugSession.customRequest("scopes", { frameId: 0 });
 
 		if (this.all_scopes) {
@@ -149,6 +155,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments) {
+		log.info("nextRequest", args);
 		if (!this.exception) {
 			this.controller.next();
 			this.sendResponse(response);
@@ -156,6 +163,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments) {
+		log.info("pauseRequest", args);
 		if (!this.exception) {
 			this.controller.break();
 			this.sendResponse(response);
@@ -163,6 +171,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected async scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments) {
+		log.info("scopesRequest", args);
 		this.controller.request_stack_frame_vars(args.frameId);
 		await this.got_scope.wait(2000);
 
@@ -180,6 +189,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 		response: DebugProtocol.SetBreakpointsResponse,
 		args: DebugProtocol.SetBreakpointsArguments,
 	) {
+		log.info("setBreakPointsRequest", args);
 		const path = (args.source.path as string).replace(/\\/g, "/");
 		const client_lines = args.lines || [];
 
@@ -216,6 +226,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) {
+		log.info("stackTraceRequest", args);
 		if (this.debug_data.last_frame) {
 			response.body = {
 				totalFrames: this.debug_data.last_frames.length,
@@ -234,6 +245,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments) {
+		log.info("stepInRequest", args);
 		if (!this.exception) {
 			this.controller.step();
 			this.sendResponse(response);
@@ -241,6 +253,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments) {
+		log.info("stepOutRequest", args);
 		if (!this.exception) {
 			this.controller.step_out();
 			this.sendResponse(response);
@@ -248,6 +261,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected terminateRequest(response: DebugProtocol.TerminateResponse, args: DebugProtocol.TerminateArguments) {
+		log.info("terminateRequest", args);
 		if (this.mode === "launch") {
 			this.controller.stop();
 			this.sendEvent(new TerminatedEvent());
@@ -256,6 +270,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 	}
 
 	protected threadsRequest(response: DebugProtocol.ThreadsResponse) {
+		log.info("threadsRequest");
 		response.body = { threads: [new Thread(0, "thread_1")] };
 		this.sendResponse(response);
 	}
@@ -264,6 +279,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 		response: DebugProtocol.VariablesResponse,
 		args: DebugProtocol.VariablesArguments,
 	) {
+		log.info("variablesRequest", args);
 		if (!this.all_scopes) {
 			response.body = {
 				variables: [],

--- a/src/debugger/godot4/debug_session.ts
+++ b/src/debugger/godot4/debug_session.ts
@@ -401,11 +401,8 @@ export class GodotDebugSession extends LoggingDebugSession {
 				!this.ongoing_inspections.includes(va.value.id) &&
 				!this.previous_inspections.includes(va.value.id)
 			) {
-				console.log(`[add_to_inspections] adding '${va.value.id}' to ongoing_inspections`);
 				this.controller.request_inspect_object(va.value.id);
 				this.ongoing_inspections.push(va.value.id);
-			} else {
-				console.log(`[add_to_inspections] skipping '${va.value.id}' already in ongoing_inspections or previous_inspections`);
 			}
 		}
 	}
@@ -416,7 +413,6 @@ export class GodotDebugSession extends LoggingDebugSession {
 		index = 0,
 		object_id: number = null,
 	): Variable {
-		console.log(`[get_variable] '${expression}' this.all_scopes.length: ${this.all_scopes.length}`);
 		let result: Variable = {
 			variable: null,
 			index: null,
@@ -429,16 +425,7 @@ export class GodotDebugSession extends LoggingDebugSession {
 			}
 
 			root = this.all_scopes.find((x) => x && x.name === "self");
-			if (root === undefined) {
-				root = this.all_scopes.find((x) => x && x.name =="member").sub_values.find((x) => x && x.name =="self");
-			}
-
-			var self_scope = this.all_scopes.find((x) => x && x.name === "id" && x.scope_path === "@.member.self");
-			if (self_scope === undefined) {
-				// self_scope = this.all_scopes.find((x) => x && x.name =="member").sub_values.find((x) => x && x.name =="self").value
-				self_scope = root.sub_values.find((x) => x && x.name =="id");
-			}
-			object_id = self_scope.value;
+			object_id = this.all_scopes.find((x) => x && x.name === "id" && x.scope_path === "@.member.self").value;
 		}
 
 		const items = expression.split(".");
@@ -547,7 +534,6 @@ export class GodotDebugSession extends LoggingDebugSession {
 			result = this.get_variable(items.join("."), result.variable, index + 1, result.object_id);
 		}
 
-		console.log(`[get_variable] ${expression}`, result);
 		return result;
 	}
 

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -67,9 +67,9 @@ async function getStackFrames(threadId: number = 1): Promise<DebugProtocol.Stack
 }
 
 async function waitForBreakpoint(breakpoint: vscode.SourceBreakpoint, ms: number): Promise<void> {
-  console.log("Wating for breakpoint", breakpoint);
+  console.log("Waiting for breakpoint", `${breakpoint.location.uri.path}:${breakpoint.location.range.start.line}, enabled: ${breakpoint.enabled}`);
   const res = await waitForActiveStackItemChange(ms);
-  console.log("Wating for breakpoint completed", breakpoint);
+  console.log("Waiting for breakpoint completed", `${breakpoint.location.uri.path}:${breakpoint.location.range.start.line}, enabled: ${breakpoint.enabled}`);
   const stackFrames = await getStackFrames();
   if (stackFrames[0].source.path !== breakpoint.location.uri.fsPath || stackFrames[0].line != breakpoint.location.range.start.line+1) {
     throw new Error(`Wrong breakpoint was hit. Expected: ${breakpoint.location.uri.fsPath}:${breakpoint.location.range.start.line+1}, Got: ${stackFrames[0].source.path}:${stackFrames[0].line}`);
@@ -127,7 +127,8 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     }
   });
 
-  setup(async () => {
+  setup(async function() {
+    console.log(`➤ Test '${this?.currentTest.title}' starting`);
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     if (vscode.debug.breakpoints) {
       await vscode.debug.removeBreakpoints(vscode.debug.breakpoints);
@@ -135,12 +136,13 @@ suite("DAP Integration Tests - Variable Scopes", () => {
   });
 
 
-  teardown(async () => {
+  teardown(async function() {
     await sleep(1000);
     if (vscode.debug.activeDebugSession !== undefined) {
       console.log("Closing debug session");
       await vscode.debug.stopDebugging();
     }
+    console.log(`⬛ Test '${this.currentTest.title}' result: ${this.currentTest.state}`);
   });
   
   test("should return correct scopes", async () => {

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -20,7 +20,7 @@ async function sleep(ms) {
  * @param scriptPath The path to the script to scan.
  * @returns An object of breakpoint names to line numbers.
  */
-async function getBreakpointLocations(scriptPath: string) {
+async function getBreakpointLocations(scriptPath: string): Promise<{ [key: string]: vscode.Location }> {
   const script_content = await fs.readFile(scriptPath, "utf-8");
   const breakpoints: { [key: string]: vscode.Location } = {};
   const breakpointRegex = /\b(breakpoint::.*)\b/g;

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -67,7 +67,9 @@ async function getStackFrames(threadId: number = 1): Promise<DebugProtocol.Stack
 }
 
 async function waitForBreakpoint(breakpoint: vscode.SourceBreakpoint, ms: number): Promise<void> {
+  console.log("Wating for breakpoint", breakpoint);
   const res = await waitForActiveStackItemChange(ms);
+  console.log("Wating for breakpoint completed", breakpoint);
   const stackFrames = await getStackFrames();
   if (stackFrames[0].source.path !== breakpoint.location.uri.fsPath || stackFrames[0].line != breakpoint.location.range.start.line+1) {
     throw new Error(`Wrong breakpoint was hit. Expected: ${breakpoint.location.uri.fsPath}:${breakpoint.location.range.start.line+1}, Got: ${stackFrames[0].source.path}:${stackFrames[0].line}`);
@@ -106,7 +108,9 @@ async function startDebugging(scene: "ScopeVars.tscn" | "ExtensiveVars.tscn" | "
     scene: scene,
     additional_options: "--headless"
   };
+  console.log(`Starting debugger for scene ${scene}`);
   const res = await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], debugConfig);
+  console.log(`Starting debugger for scene ${scene} completed`);
   if (!res) {
     throw new Error("Failed to start debugging");
   }

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -66,7 +66,7 @@ async function getStackFrames(threadId: number = 1): Promise<DebugProtocol.Stack
   return stackTraceResponse.stackFrames || [];
 }
 
-async function waitForBreakpoint(breakpoint?: vscode.SourceBreakpoint, ms?: number): Promise<void> {
+async function waitForBreakpoint(breakpoint: vscode.SourceBreakpoint, ms: number): Promise<void> {
   const res = await waitForActiveStackItemChange(ms);
   const stackFrames = await getStackFrames();
   if (stackFrames[0].source.path !== breakpoint.location.uri.fsPath || stackFrames[0].line != breakpoint.location.range.start.line+1) {
@@ -146,6 +146,10 @@ suite("DAP Integration Tests - Variable Scopes", () => {
 
     await startDebugging("ScopeVars.tscn");
     await waitForBreakpoint(breakpoint, 2000);
+
+    // TODO: current DAP needs a delay before it will return variables
+    console.log("Sleeping for 2 seconds");
+    await sleep(2000);
 
     // corresponds to file://./debug_session.ts async scopesRequest
     const res_scopes = await vscode.debug.activeDebugSession.customRequest("scopes", {frameId: 1});

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -1,26 +1,16 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { DebugProtocol } from '@vscode/debugprotocol';
+import { DebugProtocol } from "@vscode/debugprotocol";
 import chai from "chai";
 import chaiSubset from "chai-subset";
 
 chai.use(chaiSubset);
 const { expect } = chai;
 
-// Explicitly declare expect type
-declare global {
-  namespace Chai {
-      interface Assertion {
-          containSubset(expected: any): Assertion;
-      }
-  }
-}
-
 async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve,  ms));
 }
-
 
 /**
  * Given a path to a script, returns an object where each key is the name of a
@@ -35,14 +25,13 @@ async function getBreakpointLocations(scriptPath: string) {
   const breakpoints: { [key: string]: vscode.Location } = {};
   const breakpointRegex = /\b(breakpoint::.*)\b/g;
   let match: RegExpExecArray | null;
-  console.log(`Script_content`, script_content);
   while ((match = breakpointRegex.exec(script_content)) !== null) {
     const breakpointName = match[1];
     const line = match.index ? script_content.substring(0, match.index).split("\n").length : 1;
     breakpoints[breakpointName] = new vscode.Location(vscode.Uri.file(scriptPath), new vscode.Position(line - 1, 0));
   }
   return breakpoints;
-};
+}
 
 async function waitForActiveItemStackChange(ms: number = 10000): Promise<vscode.DebugThread | vscode.DebugStackFrame | undefined> {
   const res = await new Promise<vscode.DebugThread | vscode.DebugStackFrame | undefined>((resolve, reject) => {
@@ -140,7 +129,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     expect(scopes[2].name).to.equal(VariableScope[VariableScope.Globals], "Expected Globals scope");
     expect(scopes[2].variablesReference).to.equal(VariableScope.Globals, "Expected Globals variablesReference");
 
-    await vscode.debug.stopDebugging()
+    await vscode.debug.stopDebugging();
     await sleep(2000);
   })?.timeout(5000);
 
@@ -153,13 +142,13 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     await waitForBreakpoint(breakpoint);
     
     // TODO: current DAP needs a delay before it will return variables
-    console.log(`Sleeping for 2 seconds`);
+    console.log("Sleeping for 2 seconds");
     await sleep(2000);
 
     const variables = await getVariablesForScope(VariableScope.Globals);
     expect(variables).to.containSubset([{name: "GlobalScript"}]);
     
-    await vscode.debug.stopDebugging()
+    await vscode.debug.stopDebugging();
   })?.timeout(5000);
 
   test("should return local variables", async () => {
@@ -171,7 +160,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     await waitForBreakpoint(breakpoint);
 
     // TODO: current DAP needs a delay before it will return variables
-    console.log(`Sleeping for 2 seconds`);
+    console.log("Sleeping for 2 seconds");
     await sleep(2000);
 
     const variables = await getVariablesForScope(VariableScope.Locals);
@@ -179,7 +168,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     expect(variables).to.containSubset([{name: "local1"}]);
     expect(variables).to.containSubset([{name: "local2"}]);
     
-    await vscode.debug.stopDebugging()
+    await vscode.debug.stopDebugging();
   })?.timeout(5000);
 
   test("should return member variables", async () => {
@@ -191,15 +180,15 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     await waitForBreakpoint(breakpoint);
 
     // TODO: current DAP needs a delay before it will return variables
-    console.log(`Sleeping for 2 seconds`);
+    console.log("Sleeping for 2 seconds");
     await sleep(2000);
 
     const variables = await getVariablesForScope(VariableScope.Members);
     expect(variables.length).to.equal(2);
-    expect(variables).to.containSubset([{name: "self"}])
-    expect(variables).to.containSubset([{name: "member1"}])
+    expect(variables).to.containSubset([{name: "self"}]);
+    expect(variables).to.containSubset([{name: "member1"}]);
 
-    await vscode.debug.stopDebugging()
+    await vscode.debug.stopDebugging();
   })?.timeout(5000);
 
   test("should retrieve all built-in types correctly", async () => {
@@ -211,7 +200,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     await waitForBreakpoint(breakpoint);
     
     // TODO: current DAP needs a delay before it will return variables
-    console.log(`Sleeping for 2 seconds`);
+    console.log("Sleeping for 2 seconds");
     await sleep(2000);
     
     const variables = await getVariablesForScope(VariableScope.Locals);
@@ -240,7 +229,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     expect(variables).to.containSubset([{ name: "callable_var", value: "Callable()" }]);
     expect(variables).to.containSubset([{ name: "signal_var" }]);
     const signal_var = variables.find((v: any) => v.name === "signal_var");
-    expect(signal_var.value).to.match(/Signal\(member_signal\, <\d+>\)/, "Should be in format of 'Signal(member_signal, <28236055815>)'")
+    expect(signal_var.value).to.match(/Signal\(member_signal\, <\d+>\)/, "Should be in format of 'Signal(member_signal, <28236055815>)'");
   })?.timeout(50000);
 
   test("should retrieve all complex variables correctly", async () => {
@@ -252,19 +241,16 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     await waitForBreakpoint(breakpoint);
 
     // TODO: current DAP needs a delay before it will return variables
-    console.log(`Sleeping for 2 seconds`);
+    console.log("Sleeping for 2 seconds");
     await sleep(2000);
 
-    console.log(`getVariablesForScope(VariableScope.Members)`);
     const memberVariables = await getVariablesForScope(VariableScope.Members);
     
     expect(memberVariables.length).to.equal(3);
     expect(memberVariables).to.containSubset([{name: "self"}]);
     expect(memberVariables).to.containSubset([{name: "self_var"}]);
     
-    console.log(`getVariablesForScope(VariableScope.Locals)`);
     const localVariables = await getVariablesForScope(VariableScope.Locals);
-    console.log(`Done`);
     expect(localVariables.length).to.equal(4);
     expect(localVariables).to.containSubset([
       { name: "local_label", value: "Label" },
@@ -273,7 +259,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
       { name: "local_classB", value: "RefCounted" }
     ]);
     
-    await vscode.debug.stopDebugging()
+    await vscode.debug.stopDebugging();
   })?.timeout(15000);
 
   // test("Same Object Referenced by Different Variables", async () => {

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -1,0 +1,296 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { DebugProtocol } from '@vscode/debugprotocol';
+import chai from "chai";
+import chaiSubset from "chai-subset";
+
+chai.use(chaiSubset);
+const { expect } = chai;
+
+// Explicitly declare expect type
+declare global {
+  namespace Chai {
+      interface Assertion {
+          containSubset(expected: any): Assertion;
+      }
+  }
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve,  ms));
+}
+
+
+/**
+ * Given a path to a script, returns an object where each key is the name of a
+ * breakpoint (delimited by `breakpoint::`) and each value is the line number
+ * where the breakpoint appears in the script.
+ *
+ * @param scriptPath The path to the script to scan.
+ * @returns An object of breakpoint names to line numbers.
+ */
+async function getBreakpointLocations(scriptPath: string) {
+  const script_content = await fs.readFile(scriptPath, "utf-8");
+  const breakpoints: { [key: string]: vscode.Location } = {};
+  const breakpointRegex = /\b(breakpoint::.*)\b/g;
+  let match: RegExpExecArray | null;
+  console.log(`Script_content`, script_content);
+  while ((match = breakpointRegex.exec(script_content)) !== null) {
+    const breakpointName = match[1];
+    const line = match.index ? script_content.substring(0, match.index).split("\n").length : 1;
+    breakpoints[breakpointName] = new vscode.Location(vscode.Uri.file(scriptPath), new vscode.Position(line - 1, 0));
+  }
+  return breakpoints;
+};
+
+async function waitForActiveItemStackChange(ms: number = 10000): Promise<vscode.DebugThread | vscode.DebugStackFrame | undefined> {
+  const res = await new Promise<vscode.DebugThread | vscode.DebugStackFrame | undefined>((resolve, reject) => {
+      const debugListener = vscode.debug.onDidChangeActiveStackItem((event) => {
+        debugListener.dispose();
+        resolve(vscode.debug.activeStackItem);
+      });
+
+      // Timeout fallback in case stack item never changes
+      setTimeout(() => {
+          debugListener.dispose();
+          console.warn();
+          reject("Breakpoint was not hit within the timeout period");
+      }, ms);
+  });
+
+  return res;
+}
+
+async function getStackFrames(): Promise<DebugProtocol.StackFrame[]> {
+  // Ensure there is an active debug session
+  if (!vscode.debug.activeDebugSession) {
+      throw new Error("No active debug session found");
+  }
+
+  // Request the current stack trace
+  const stackTraceResponse = await vscode.debug.activeDebugSession.customRequest("stackTrace", {
+      threadId: 1, // Adjust threadId as needed
+  });
+
+  // Extract and return the stack frames
+  return stackTraceResponse.stackFrames || [];
+}
+
+async function waitForBreakpoint(breakpoint?: vscode.SourceBreakpoint, ms?: number): Promise<void> {
+  const res = await waitForActiveItemStackChange(ms);
+  const stackFrames = await getStackFrames();
+  if (stackFrames[0].source.path !== breakpoint.location.uri.fsPath || stackFrames[0].line != breakpoint.location.range.start.line+1) {
+    throw new Error(`Wrong breakpoint was hit. Expected: ${breakpoint.location.uri.fsPath}:${breakpoint.location.range.start.line+1}, Got: ${stackFrames[0].source.path}:${stackFrames[0].line}`);
+  }
+}
+
+enum VariableScope {
+  Locals  = 1,
+  Members = 2,
+  Globals = 3
+}
+
+async function getVariablesForScope(scope: VariableScope): Promise<DebugProtocol.Variable[]> {
+  const variablesResponse = await vscode.debug.activeDebugSession?.customRequest("variables", {
+    variablesReference: scope
+  });
+  return variablesResponse?.variables || [];
+}
+
+async function startDebugging(scene: "ScopeVars.tscn" | "ExtensiveVars.tscn" | "BuiltInTypes.tscn" = "ScopeVars.tscn"): Promise<void> {
+  const debugConfig: vscode.DebugConfiguration = {
+    type: "godot",
+    request: "launch",
+    name: "Godot Debug",
+    scene: scene
+  };
+  const res = await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], debugConfig);
+  if (!res) {
+    throw new Error("Failed to start debugging");
+  }
+}
+
+suite("DAP Integration Tests - Variable Scopes", () => {
+  const workspaceFolder = path.resolve(__dirname, "../../../test_projects/test-dap-project-godot4");
+
+  teardown(async () => {
+    await vscode.debug.stopDebugging();
+  });
+  
+  test("should return correct scopes", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ScopeVars.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::ScopeVars::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("ScopeVars.tscn");
+    await waitForBreakpoint(breakpoint, 2000);
+
+    const res_scopes = await vscode.debug.activeDebugSession.customRequest("scopes", {frameId: 1});
+
+    expect(res_scopes).to.exist;
+    expect(res_scopes.scopes).to.exist;
+
+    const scopes = res_scopes.scopes;
+    expect(scopes.length).to.equal(3, "Expected 3 scopes");
+    expect(scopes[0].name).to.equal(VariableScope[VariableScope.Locals], "Expected Locals scope");
+    expect(scopes[0].variablesReference).to.equal(VariableScope.Locals, "Expected Locals variablesReference");
+    expect(scopes[1].name).to.equal(VariableScope[VariableScope.Members], "Expected Members scope");
+    expect(scopes[1].variablesReference).to.equal(VariableScope.Members, "Expected Members variablesReference");
+    expect(scopes[2].name).to.equal(VariableScope[VariableScope.Globals], "Expected Globals scope");
+    expect(scopes[2].variablesReference).to.equal(VariableScope.Globals, "Expected Globals variablesReference");
+
+    await vscode.debug.stopDebugging()
+    await sleep(2000);
+  })?.timeout(5000);
+
+  test("should return global variables", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ScopeVars.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::ScopeVars::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("ScopeVars.tscn");
+    await waitForBreakpoint(breakpoint);
+    
+    // TODO: current DAP needs a delay before it will return variables
+    console.log(`Sleeping for 2 seconds`);
+    await sleep(2000);
+
+    const variables = await getVariablesForScope(VariableScope.Globals);
+    expect(variables).to.containSubset([{name: "GlobalScript"}]);
+    
+    await vscode.debug.stopDebugging()
+  })?.timeout(5000);
+
+  test("should return local variables", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ScopeVars.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::ScopeVars::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("ScopeVars.tscn");
+    await waitForBreakpoint(breakpoint);
+
+    // TODO: current DAP needs a delay before it will return variables
+    console.log(`Sleeping for 2 seconds`);
+    await sleep(2000);
+
+    const variables = await getVariablesForScope(VariableScope.Locals);
+    expect(variables.length).to.equal(2);
+    expect(variables).to.containSubset([{name: "local1"}]);
+    expect(variables).to.containSubset([{name: "local2"}]);
+    
+    await vscode.debug.stopDebugging()
+  })?.timeout(5000);
+
+  test("should return member variables", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ScopeVars.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::ScopeVars::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("ScopeVars.tscn");
+    await waitForBreakpoint(breakpoint);
+
+    // TODO: current DAP needs a delay before it will return variables
+    console.log(`Sleeping for 2 seconds`);
+    await sleep(2000);
+
+    const variables = await getVariablesForScope(VariableScope.Members);
+    expect(variables.length).to.equal(2);
+    expect(variables).to.containSubset([{name: "self"}])
+    expect(variables).to.containSubset([{name: "member1"}])
+
+    await vscode.debug.stopDebugging()
+  })?.timeout(5000);
+
+  test("should retrieve all built-in types correctly", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "BuiltInTypes.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::BuiltInTypes::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("BuiltInTypes.tscn");
+    await waitForBreakpoint(breakpoint);
+    
+    // TODO: current DAP needs a delay before it will return variables
+    console.log(`Sleeping for 2 seconds`);
+    await sleep(2000);
+    
+    const variables = await getVariablesForScope(VariableScope.Locals);
+
+    expect(variables).to.containSubset([{ name: "int_var", value: "42" }]);
+    expect(variables).to.containSubset([{ name: "float_var", value: "3.14" }]);
+    expect(variables).to.containSubset([{ name: "bool_var", value: "true" }]);
+    expect(variables).to.containSubset([{ name: "string_var", value: "Hello, Godot!" }]);
+    expect(variables).to.containSubset([{ name: "nil_var", value: "null" }]);
+    expect(variables).to.containSubset([{ name: "vector2", value: "Vector2(10, 20)" }]);
+    expect(variables).to.containSubset([{ name: "vector3", value: "Vector3(1, 2, 3)" }]);
+    expect(variables).to.containSubset([{ name: "rect2", value: "Rect2((0, 0) - (100, 50))" }]);
+    expect(variables).to.containSubset([{ name: "quaternion", value: "Quat(0, 0, 0, 1)" }]);
+    // expect(variables).to.containSubset([{ name: "simple_array", value: "[1, 2, 3]" }]);
+    expect(variables).to.containSubset([{ name: "simple_array", value: "Array[3]" }]);
+    // expect(variables).to.containSubset([{ name: "nested_dict.nested_key", value: `"Nested Value"` }]);
+    // expect(variables).to.containSubset([{ name: "nested_dict.sub_dict.sub_key", value: "99" }]);
+    expect(variables).to.containSubset([{ name: "nested_dict", value: "Dictionary[2]" }]);
+    // expect(variables).to.containSubset([{ name: "byte_array", value: "[0, 1, 2, 255]" }]);
+    expect(variables).to.containSubset([{ name: "byte_array", value: "Array[4]" }]);
+    // expect(variables).to.containSubset([{ name: "int32_array", value: "[100, 200, 300]" }]);
+    expect(variables).to.containSubset([{ name: "int32_array", value: "Array[3]" }]);
+    expect(variables).to.containSubset([{ name: "color_var", value: "Color(1, 0, 0, 1)" }]);
+    expect(variables).to.containSubset([{ name: "aabb_var", value: "AABB((0, 0, 0), (1, 1, 1))" }]);
+    expect(variables).to.containSubset([{ name: "plane_var", value: "Plane(0, 1, 0, -5)" }]);
+    expect(variables).to.containSubset([{ name: "callable_var", value: "Callable()" }]);
+    expect(variables).to.containSubset([{ name: "signal_var" }]);
+    const signal_var = variables.find((v: any) => v.name === "signal_var");
+    expect(signal_var.value).to.match(/Signal\(member_signal\, <\d+>\)/, "Should be in format of 'Signal(member_signal, <28236055815>)'")
+  })?.timeout(50000);
+
+  test("should retrieve all complex variables correctly", async () => {
+    const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ExtensiveVars.gd"));
+    const breakpoint = new vscode.SourceBreakpoint(breakpointLocations["breakpoint::ExtensiveVars::_ready"]);
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    await startDebugging("ExtensiveVars.tscn");
+    await waitForBreakpoint(breakpoint);
+
+    // TODO: current DAP needs a delay before it will return variables
+    console.log(`Sleeping for 2 seconds`);
+    await sleep(2000);
+
+    console.log(`getVariablesForScope(VariableScope.Members)`);
+    const memberVariables = await getVariablesForScope(VariableScope.Members);
+    
+    expect(memberVariables.length).to.equal(3);
+    expect(memberVariables).to.containSubset([{name: "self"}]);
+    expect(memberVariables).to.containSubset([{name: "self_var"}]);
+    
+    console.log(`getVariablesForScope(VariableScope.Locals)`);
+    const localVariables = await getVariablesForScope(VariableScope.Locals);
+    console.log(`Done`);
+    expect(localVariables.length).to.equal(4);
+    expect(localVariables).to.containSubset([
+      { name: "local_label", value: "Label" },
+      { name: "local_self_var_through_label", value: "Node2D" },
+      { name: "local_classA", value: "RefCounted" },
+      { name: "local_classB", value: "RefCounted" }
+    ]);
+    
+    await vscode.debug.stopDebugging()
+  })?.timeout(15000);
+
+  // test("Same Object Referenced by Different Variables", async () => {
+  //   const variables = await getVariablesForScope(VariableScope.Locals);
+  //   const varA = variables.find((v: any) => v.name === "varA");
+  //   const varB = variables.find((v: any) => v.name === "varB");
+
+  //   expect(varA).to.exist("Variable A not found");
+  //   expect(varB).to.exist("Variable B not found");
+  //   expect(varA.value).to.equal(varB.value, "varA and varB do not reference the same object");
+  // });
+
+  // test("Circular Reference in Object Variables", async () => {
+  //   const variables = await getVariablesForScope(VariableScope.Members);
+  //   const circularVar = variables.find((v: any) => v.name === "circularVar");
+
+  //   expect(circularVar).to.exist("Circular reference variable not found");
+  //   expect(circularVar.value).to.equal("[Circular]", "Circular reference not detected");
+  // });
+});

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -183,7 +183,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     
     await sleep(1000);
     await vscode.debug.stopDebugging();
-  })?.timeout(5000);
+  })?.timeout(7000);
 
   test("should return local variables", async () => {
     const breakpointLocations = await getBreakpointLocations(path.join(workspaceFolder, "ScopeVars.gd"));

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -103,7 +103,8 @@ async function startDebugging(scene: "ScopeVars.tscn" | "ExtensiveVars.tscn" | "
     type: "godot",
     request: "launch",
     name: "Godot Debug",
-    scene: scene
+    scene: scene,
+    additional_options: "--headless"
   };
   const res = await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], debugConfig);
   if (!res) {

--- a/src/debugger/godot4/debugger_variables.test.ts
+++ b/src/debugger/godot4/debugger_variables.test.ts
@@ -172,7 +172,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     vscode.debug.addBreakpoints([breakpoint]);
 
     await startDebugging("ScopeVars.tscn");
-    await waitForBreakpoint(breakpoint);
+    await waitForBreakpoint(breakpoint, 2000);
     
     // TODO: current DAP needs a delay before it will return variables
     console.log("Sleeping for 2 seconds");
@@ -191,7 +191,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     vscode.debug.addBreakpoints([breakpoint]);
 
     await startDebugging("ScopeVars.tscn");
-    await waitForBreakpoint(breakpoint);
+    await waitForBreakpoint(breakpoint, 2000);
 
     // TODO: current DAP needs a delay before it will return variables
     console.log("Sleeping for 2 seconds");
@@ -212,7 +212,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     vscode.debug.addBreakpoints([breakpoint]);
 
     await startDebugging("ScopeVars.tscn");
-    await waitForBreakpoint(breakpoint);
+    await waitForBreakpoint(breakpoint, 2000);
 
     // TODO: current DAP needs a delay before it will return variables
     console.log("Sleeping for 2 seconds");
@@ -233,7 +233,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     vscode.debug.addBreakpoints([breakpoint]);
 
     await startDebugging("BuiltInTypes.tscn");
-    await waitForBreakpoint(breakpoint);
+    await waitForBreakpoint(breakpoint, 2000);
     
     // TODO: current DAP needs a delay before it will return variables
     console.log("Sleeping for 2 seconds");
@@ -277,7 +277,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
     vscode.debug.addBreakpoints([breakpoint]);
 
     await startDebugging("ExtensiveVars.tscn");
-    await waitForBreakpoint(breakpoint);
+    await waitForBreakpoint(breakpoint, 2000);
 
     // TODO: current DAP needs a delay before it will return variables
     console.log("Sleeping for 2 seconds");

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -19,7 +19,7 @@ import { killSubProcesses, subProcess } from "../../utils/subspawn";
 import { GodotStackFrame, GodotStackVars, GodotVariable } from "../debug_runtime";
 import { AttachRequestArguments, LaunchRequestArguments, pinnedScene } from "../debugger";
 import { GodotDebugSession } from "./debug_session";
-import { build_sub_values, parse_next_scene_node, split_buffers } from "./helpers";
+import { get_sub_values, parse_next_scene_node, split_buffers } from "./helpers";
 import { VariantDecoder } from "./variables/variant_decoder";
 import { VariantEncoder } from "./variables/variant_encoder";
 import { RawObject } from "./variables/variants";
@@ -395,13 +395,15 @@ export class ServerController {
 				for (const prop of properties) {
 					rawObject.set(prop[0], prop[5]);
 				}
-				const inspectedVariable = { name: "", value: rawObject };
-				build_sub_values(inspectedVariable);
-				if (this.session.inspect_callbacks.has(BigInt(id))) {
-					this.session.inspect_callbacks.get(BigInt(id))(inspectedVariable.name, inspectedVariable);
+				const sub_values = get_sub_values(rawObject);
+				
+				const inspect_callback = this.session.inspect_callbacks.get(BigInt(id))
+				if (inspect_callback !== undefined) {
+					const inspectedVariable = { name: "", value: rawObject, sub_values: sub_values } as GodotVariable;
+					inspect_callback(inspectedVariable.name, inspectedVariable);
 					this.session.inspect_callbacks.delete(BigInt(id));
 				}
-				this.session.set_inspection(id, inspectedVariable);
+				this.session.set_inspection(id, rawObject, sub_values);
 				break;
 			}
 			case "stack_dump": {
@@ -641,8 +643,8 @@ export class ServerController {
 			throw new Error("More stack frame variables were sent than expected.");
 		}
 
-		const variable: GodotVariable = { name, value, type };
-		build_sub_values(variable);
+		const sub_values = get_sub_values(value);
+		const variable = { name, value, type, sub_values } as GodotVariable;
 
 		const scopeName = ["locals", "members", "globals"][scope];
 		this.partialStackVars[scopeName].push(variable);

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -397,7 +397,7 @@ export class ServerController {
 				}
 				const sub_values = get_sub_values(rawObject);
 				
-				const inspect_callback = this.session.inspect_callbacks.get(BigInt(id))
+				const inspect_callback = this.session.inspect_callbacks.get(BigInt(id));
 				if (inspect_callback !== undefined) {
 					const inspectedVariable = { name: "", value: rawObject, sub_values: sub_values } as GodotVariable;
 					inspect_callback(inspectedVariable.name, inspectedVariable);

--- a/src/debugger/godot4/variables/variants.ts
+++ b/src/debugger/godot4/variables/variants.ts
@@ -471,7 +471,7 @@ export class Signal implements GDObject {
 	constructor(public name: string, public oid: ObjectId) {}
 
 	public stringify_value(): string {
-		return `${this.name}() ${this.oid.stringify_value()}`;
+		return `(${this.name}, ${this.oid.stringify_value()})`;
 	}
 
 	public sub_values(): GodotVariable[] {

--- a/src/debugger/scene_tree_provider.ts
+++ b/src/debugger/scene_tree_provider.ts
@@ -5,6 +5,7 @@ import {
 	ProviderResult,
 	TreeItem,
 	TreeItemCollapsibleState,
+	Uri
 } from "vscode";
 import path = require("path");
 import { get_extension_uri } from "../utils";
@@ -81,8 +82,8 @@ export class SceneNode extends TreeItem {
 		const iconName = class_name + ".svg";
 
 		this.iconPath = {
-			light: path.join(iconDir, "light", iconName),
-			dark: path.join(iconDir, "dark", iconName),
+			light: Uri.file(path.join(iconDir, "light", iconName)),
+			dark: Uri.file(path.join(iconDir, "dark", iconName)),
 		};
 	}
 }

--- a/src/formatter/formatter.test.ts
+++ b/src/formatter/formatter.test.ts
@@ -138,6 +138,10 @@ function parse_test_file(content: string): Test[] {
 suite("GDScript Formatter Tests", () => {
 	const testFiles = fs.readdirSync(snapshotsFolderPath, { withFileTypes: true, recursive: true });
 
+	teardown(async () => {
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+	});
+
 	for (const file of testFiles.filter((f) => f.isFile())) {
 		if (["in.gd", "out.gd"].includes(file.name) || !file.name.endsWith(".gd")) {
 			continue;

--- a/src/scene_tools/types.ts
+++ b/src/scene_tools/types.ts
@@ -2,6 +2,7 @@ import {
 	TreeItem,
 	TreeItemCollapsibleState,
 	MarkdownString,
+	Uri
 } from "vscode";
 import * as path from "path";
 import { get_extension_uri } from "../utils";
@@ -31,8 +32,8 @@ export class SceneNode extends TreeItem {
 		const iconName = className + ".svg";
 
 		this.iconPath = {
-			light: path.join(iconDir, "light", iconName),
-			dark: path.join(iconDir, "dark", iconName),
+			light: Uri.file(path.join(iconDir, "light", iconName)),
+			dark: Uri.file(path.join(iconDir, "dark", iconName)),
 		};
 	}
 

--- a/test_projects/test-dap-project-godot4/.vscode/launch.json
+++ b/test_projects/test-dap-project-godot4/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": "GDScript: Launch ScopeVars.tscn",
+        "type": "godot",
+        "request": "launch",
+        "project": "${workspaceFolder}",
+        "scene": "ScopeVars.tscn"
+        // "debug_collisions": false,
+        // "debug_paths": false,
+        // "debug_navigation": false,
+        // "additional_options": ""
+    },
+    {
+        "name": "GDScript: Launch ExtensiveVars.tscn",
+        "type": "godot",
+        "request": "launch",
+        "project": "${workspaceFolder}",
+        "scene": "ExtensiveVars.tscn"
+    },
+    {
+        "name": "GDScript: Launch BuiltInTypes.tscn",
+        "type": "godot",
+        "request": "launch",
+        "project": "${workspaceFolder}",
+        "scene": "BuiltInTypes.tscn"
+    },
+    {
+        "name": "GDScript: Launch NodeVars.tscn",
+        "type": "godot",
+        "request": "launch",
+        "project": "${workspaceFolder}",
+        "scene": "NodeVars.tscn"
+    }
+    ]
+}

--- a/test_projects/test-dap-project-godot4/.vscode/settings.json
+++ b/test_projects/test-dap-project-godot4/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "godotTools.editorPath.godot4": "s:\\programs\\Godot_v4.3-stable_win64.exe\\Godot_v4.3-stable_win64.exe"
-}

--- a/test_projects/test-dap-project-godot4/.vscode/settings.json
+++ b/test_projects/test-dap-project-godot4/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "godotTools.editorPath.godot4": "s:\\programs\\Godot_v4.3-stable_win64.exe\\Godot_v4.3-stable_win64.exe"
+}

--- a/test_projects/test-dap-project-godot4/BuiltInTypes.gd
+++ b/test_projects/test-dap-project-godot4/BuiltInTypes.gd
@@ -1,0 +1,39 @@
+extends Node
+
+signal member_signal
+signal member_signal_with_parameters(my_param1: String)
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+  var int_var = 42
+  var float_var = 3.14
+  var bool_var = true
+  var string_var = "Hello, Godot!"
+  var nil_var = null
+  var vector2 = Vector2(10, 20)
+  var vector3 = Vector3(1, 2, 3)
+  var rect2 = Rect2(0, 0, 100, 50)
+  var quaternion = Quaternion(0, 0, 0, 1)
+  var simple_array = [1, 2, 3]
+  var nested_dict = {
+      "nested_key": "Nested Value",
+      "sub_dict": {"sub_key": 99}
+  }  
+  var byte_array = PackedByteArray([0, 1, 2, 255])
+  var int32_array = PackedInt32Array([100, 200, 300])
+  var color_var = Color(1, 0, 0, 1) # Red color
+  var aabb_var = AABB(Vector3(0, 0, 0), Vector3(1, 1, 1))
+  var plane_var = Plane(Vector3(0, 1, 0), -5)
+
+  var callable_var = self.my_callable_func
+
+  var signal_var = member_signal
+  member_signal.connect(singal_connected_func)
+
+  print("breakpoint::BuiltInTypes::_ready")
+  
+func my_callable_func():
+  pass
+
+func singal_connected_func():
+  pass

--- a/test_projects/test-dap-project-godot4/BuiltInTypes.tscn
+++ b/test_projects/test-dap-project-godot4/BuiltInTypes.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://d0ovhv6f38jj4"]
+
+[ext_resource type="Script" path="res://BuiltInTypes.gd" id="1_2dpge"]
+
+[node name="BuiltInTypes" type="Node"]
+script = ExtResource("1_2dpge")
+
+[node name="Label" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 23.0
+text = "Built-in types"

--- a/test_projects/test-dap-project-godot4/ExtensiveVars.gd
+++ b/test_projects/test-dap-project-godot4/ExtensiveVars.gd
@@ -1,0 +1,39 @@
+extends Node2D
+
+var self_var := self
+@onready var label: ExtensiveVars_Label = $Label
+
+class ClassA:
+  var member_classB
+  var member_self := self
+  
+class ClassB:
+  var member_classA
+
+
+func _ready() -> void:
+  var local_label := label
+  var local_self_var_through_label := label.parent_var
+  
+  var local_classA = ClassA.new()
+  var local_classB = ClassB.new()
+  local_classA.member_classB = local_classB
+  local_classB.member_classA = local_classA
+
+  # Circular reference.
+  # Note: that causes the godot engine to omit this variable, since stack_frame_var cannot be completed and sent
+  # https://github.com/godotengine/godot/issues/76019
+  # var dict = {}
+  # dict["self_ref"] = dict
+  
+  print("breakpoint::ExtensiveVars::_ready")
+
+func _process(delta: float) -> void:
+  var local_label := label
+  var local_self_var_through_label := label.parent_var
+  
+  var local_classA = ClassA.new()
+  var local_classB = ClassB.new()
+  local_classA.member_classB = local_classB
+  local_classB.member_classA = local_classA
+  pass

--- a/test_projects/test-dap-project-godot4/ExtensiveVars.gd
+++ b/test_projects/test-dap-project-godot4/ExtensiveVars.gd
@@ -10,7 +10,6 @@ class ClassA:
 class ClassB:
   var member_classA
 
-
 func _ready() -> void:
   var local_label := label
   var local_self_var_through_label := label.parent_var

--- a/test_projects/test-dap-project-godot4/ExtensiveVars.tscn
+++ b/test_projects/test-dap-project-godot4/ExtensiveVars.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://bsonfthpqa3dx"]
+
+[ext_resource type="Script" path="res://ExtensiveVars.gd" id="1_fnilr"]
+[ext_resource type="Script" path="res://ExtensiveVars_Label.gd" id="2_jijf2"]
+
+[node name="ExtensiveVars" type="Node2D"]
+script = ExtResource("1_fnilr")
+
+[node name="Label" type="Label" parent="."]
+text = "Extensive Vars scene"
+script = ExtResource("2_jijf2")
+metadata/_edit_use_anchors_ = true

--- a/test_projects/test-dap-project-godot4/ExtensiveVars_Label.gd
+++ b/test_projects/test-dap-project-godot4/ExtensiveVars_Label.gd
@@ -1,0 +1,14 @@
+extends Label
+
+class_name ExtensiveVars_Label
+
+@onready var parent_var: Node2D = $".."
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+  pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+  pass

--- a/test_projects/test-dap-project-godot4/GlobalScript.gd
+++ b/test_projects/test-dap-project-godot4/GlobalScript.gd
@@ -1,0 +1,3 @@
+extends Node
+
+var globalMember := "global member"

--- a/test_projects/test-dap-project-godot4/Node1.gd
+++ b/test_projects/test-dap-project-godot4/Node1.gd
@@ -1,0 +1,8 @@
+extends Node
+
+@onready var parent_node: Node2D = $".."
+@onready var sibling_node2: Node = $"../node2"
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+  pass # Replace with function body.

--- a/test_projects/test-dap-project-godot4/NodeVars.gd
+++ b/test_projects/test-dap-project-godot4/NodeVars.gd
@@ -1,0 +1,9 @@
+extends Node2D
+
+@onready var node_1: Node = $node1
+@onready var node_2: Node = $node2
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+  print("breakpoint::NodeVars::_ready")
+  pass

--- a/test_projects/test-dap-project-godot4/NodeVars.tscn
+++ b/test_projects/test-dap-project-godot4/NodeVars.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3 uid="uid://xrjtth0d2nc5"]
+
+[ext_resource type="Script" path="res://NodeVars.gd" id="1_6eeca"]
+[ext_resource type="Script" path="res://Node1.gd" id="2_bl41t"]
+
+[node name="NodeVars" type="Node2D"]
+script = ExtResource("1_6eeca")
+
+[node name="node1" type="Node" parent="."]
+script = ExtResource("2_bl41t")
+
+[node name="node2" type="Node" parent="."]
+
+[node name="Label" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 23.0
+text = "NodeVars"

--- a/test_projects/test-dap-project-godot4/ScopeVars.gd
+++ b/test_projects/test-dap-project-godot4/ScopeVars.gd
@@ -1,0 +1,8 @@
+extends Node
+
+var member1 := TestClassA.new()
+
+func _ready() -> void:
+  var local1 := TestClassA.new()
+  var local2 = GlobalScript.globalMember
+  print("breakpoint::ScopeVars::_ready")

--- a/test_projects/test-dap-project-godot4/ScopeVars.tscn
+++ b/test_projects/test-dap-project-godot4/ScopeVars.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://g5gqewj2i2xs"]
+
+[ext_resource type="Script" path="res://ScopeVars.gd" id="1_wtcpp"]
+
+[node name="RootNode" type="Node"]
+script = ExtResource("1_wtcpp")
+
+[node name="Label" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 23.0
+text = "Godot test project"

--- a/test_projects/test-dap-project-godot4/TestClassA.gd
+++ b/test_projects/test-dap-project-godot4/TestClassA.gd
@@ -1,0 +1,5 @@
+class_name TestClassA
+
+var testclassa_member1 := "member1"
+
+var testclassa_member2: Node

--- a/test_projects/test-dap-project-godot4/project.godot
+++ b/test_projects/test-dap-project-godot4/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Test DAP project godot4"
+run/main_scene="res://ScopeVars.tscn"
+config/features=PackedStringArray("4.3", "Forward Plus")
+
+[autoload]
+
+GlobalScript="*res://GlobalScript.gd"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
 		"rootDir": "src",
 		"strict": false,
 		"skipLibCheck": true,
-		"allowJs": true
+		"allowJs": true,
+		"strictBindCallApply": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Fixes for get variables issues
1. Same reference but different variable override fix, which resulted in variables being lost
** Now different GodotVariable instances are used for different variables with same reference
** const replacement = {value: rawObject, sub_values: sub_values } as GodotVariable;
2. 'Signal' type handling crash and string representation fix
** value.sub_values()?.map
3. Empty scopes return fix
** if (this.ongoing_inspections.length === 0  && stackVars.remaining == 0)
4. Various splice from findIndex fixes (where findIndex can return -1)
5. Added variables tests
**  updated vscode types to version 1.96 to use `onDidChangeActiveStackItem` for breakpoint hit detection in tests
1 & 3 should fix https://github.com/godotengine/godot-vscode-plugin/issues/779