### PR TITLE
Add print_rich() support to Debug Console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@vscode/debugadapter": "^1.64.0",
 				"@vscode/debugprotocol": "^1.64.0",
 				"await-notify": "^1.0.1",
+				"bbcode-to-ansi": "^1.0.0",
 				"global": "^4.4.0",
 				"marked": "^4.0.11",
 				"net": "^1.0.2",
@@ -2032,6 +2033,11 @@
 				}
 			],
 			"optional": true
+		},
+		"node_modules/bbcode-to-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/bbcode-to-ansi/-/bbcode-to-ansi-1.0.0.tgz",
+			"integrity": "sha512-YQVaDdsVP2590q2AD3oTuSQecpx3YF2+gAimSbbmdjdvI8O8AOmEiTRLiRa1l2UoKjmbNh4e20s4XlRLk2n7ww=="
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -891,6 +891,7 @@
 		"@vscode/debugadapter": "^1.64.0",
 		"@vscode/debugprotocol": "^1.64.0",
 		"await-notify": "^1.0.1",
+		"bbcode-to-ansi": "^1.0.0",
 		"global": "^4.4.0",
 		"marked": "^4.0.11",
 		"net": "^1.0.2",

--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -23,9 +23,12 @@ import { build_sub_values, parse_next_scene_node, split_buffers } from "./helper
 import { VariantDecoder } from "./variables/variant_decoder";
 import { VariantEncoder } from "./variables/variant_encoder";
 import { RawObject } from "./variables/variants";
+import BBCodeToAnsi from 'bbcode-to-ansi';
 
 const log = createLogger("debugger.controller", { output: "Godot Debugger" });
 const socketLog = createLogger("debugger.socket");
+//initialize bbcodeParser and set default output color to grey
+const bbcodeParser = new BBCodeToAnsi("\u001b[38;2;211;211;211m");
 
 class Command {
 	public command: string = "";
@@ -439,9 +442,8 @@ export class ServerController {
 					this.didFirstOutput = true;
 					// this.request_scene_tree();
 				}
-				const lines = command.parameters[0];
-				for (const line of lines) {
-					debug.activeDebugConsole.appendLine(ansi.bright.blue + line);
+				for (var output in command.parameters[0]){
+					command.parameters[0][output].split("\n").forEach(line => debug.activeDebugConsole.appendLine(bbcodeParser.parse(line)))
 				}
 				break;
 			}


### PR DESCRIPTION
Adds print_rich()/bbcode support to Debug Console
Sets Debug Console text color to grey (To match Godot console output)
Changes how lines are outputted to Debug Console. (Previously was printing lines in chunks/groups instead of line by line)

Limitations:
1. Debug console will still parse bbcode in regular print() statements. I am not sure if there is a way to determine if print_rich() was used...
2. Not supported for Godot 3.6 or below
3. [center] and [right] tags are emulated with spaces. May not be accurate depending on terminal size.

Tested working on Linux, Windows
Tested working on Godot4.4b3,Godot4.3

using this to parse https://github.com/jnoel-dev/bbcode-to-ansi based on @Calinou 's https://github.com/Calinou/godot-bbcode-to-ansi

before
![image](https://github.com/user-attachments/assets/e063ff44-ec9f-4e21-806e-d96033f927d4)

after
![image](https://github.com/user-attachments/assets/38104019-e3e2-4421-aeb3-96c406d3471b)
