### PR TITLE
Fix #796 - Fixes multi-packet responses breaking things when starting or ending in a multi-byte UTF-8 sequence

### DIFF
--- a/src/lsp/MessageIO.ts
+++ b/src/lsp/MessageIO.ts
@@ -49,7 +49,7 @@ export class MessageIO extends EventEmitter {
 				resolve();
 			});
 			socket.on("data", (chunk: Buffer) => {
-				this.emit("data", chunk.toString());
+				this.emit("data", chunk);
 			});
 			// socket.on("end", this.on_disconnected.bind(this));
 			socket.on("error", () => {


### PR DESCRIPTION
Please see the issue #796 for more details.