### PR TITLE
Add region block as a language grammar scope

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -74,6 +74,7 @@
 				{ "include": "#square_braces" },
 				{ "include": "#round_braces" },
 				{ "include": "#function_call" },
+				{ "include": "#region"},
 				{ "include": "#comment" },
 				{ "include": "#self" },
 				{ "include": "#func" },
@@ -82,6 +83,10 @@
 				{ "include": "#pascal_case_class" },
 				{ "include": "#line_continuation" }
 			]
+		},
+		"region": {
+			"match": "#(end)?region.*$\\n?",
+			"name": "keyword.language.region.gdscript"
 		},
 		"comment": {
 			"match": "(##|#).*$\\n?",


### PR DESCRIPTION
In Godot's script editor, region blocks and comments are highlighted in different colors for better readability
this tiny PR just adds a region scope to replicate that behavior 
![editor_gdscript](https://github.com/user-attachments/assets/d1a56706-ce3f-412d-a4f3-bb19ccbf6ed5)  
![vscode_result_without_override](https://github.com/user-attachments/assets/0cf39f52-01f4-4e2c-b96c-852caf2207ba)

this also allows regions to be customized as their own separate thing
![overriding_color](https://github.com/user-attachments/assets/85f608f6-e335-4ce9-976e-7d29e9e6795a)
![vscode_result_with_override](https://github.com/user-attachments/assets/09e86ef7-ae2a-4afe-8fca-dae5bb43b376)

I'm not familiar with VSCode grammar scopes so apologies if the scope isn't correct

there's also the option of capturing the name part of the region, but I'm not sure what scope that would have to be