### PR TITLE
Fix scene preview with nodes, that have spaces in names

### DIFF
--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -87,9 +87,9 @@ export class SceneParser {
 		const nodeRegex = /\[node.*/g;
 		for (const match of text.matchAll(nodeRegex)) {
 			const line = match[0];
-			const name = line.match(/name="([\w]+)"/)?.[1];
+			const name = line.match(/name="([^.:@/"%]+)"/)?.[1];
 			const type = line.match(/type="([\w]+)"/)?.[1] ?? "PackedScene";
-			let parent = line.match(/parent="([\w\/.]+)"/)?.[1];
+			let parent = line.match(/parent="(([^.:@/"%]|[\/.])+)"/)?.[1];
 			const instance = line.match(/instance=ExtResource\(\s*"?([\w]+)"?\s*\)/)?.[1];
 
 			// leaving this in case we have a reason to use these node paths in the future


### PR DESCRIPTION
Nodes can have names, that contain some special characters (including spaces):
![image](https://github.com/user-attachments/assets/c7c95b0a-4e27-4a8a-b7f1-5ce895656a76)

But some characters are not allowed:
![image](https://github.com/user-attachments/assets/69223be2-cbae-41f5-98f1-ffa3bf1e9e75)

Based on this list, I changed the regular expression, that parses the scene.

Before:
![image](https://github.com/user-attachments/assets/6b981885-2a79-428b-9247-3817046184f8)


After:

![image](https://github.com/user-attachments/assets/f549bcd9-71d6-443f-b092-1f9903d80633)


Fixes #688