### PR TITLE
Scene Preview Improvements (relative path drag/drop)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import {
 	get_project_dir,
 	get_project_version,
 	verify_godot_version,
+	convert_uri_to_resource_path,
 } from "./utils";
 import { prompt_for_godot_executable } from "./utils/prompts";
 import { killSubProcesses, subProcess } from "./utils/subspawn";
@@ -58,7 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
 	globals.debug = new GodotDebugger(context);
 	globals.scenePreviewProvider = new ScenePreviewProvider(context);
 	globals.linkProvider = new GDDocumentLinkProvider(context);
-    globals.dropsProvider = new GDDocumentDropEditProvider(context);
+	globals.dropsProvider = new GDDocumentDropEditProvider(context);
 	globals.hoverProvider = new GDHoverProvider(context);
 	globals.inlayProvider = new GDInlayHintsProvider(context);
 	globals.formattingProvider = new FormattingProvider(context);
@@ -122,19 +123,12 @@ export function deactivate(): Thenable<void> {
 	});
 }
 
-function copy_resource_path(uri: vscode.Uri) {
+async function copy_resource_path(uri: vscode.Uri) {
 	if (!uri) {
 		uri = vscode.window.activeTextEditor.document.uri;
 	}
 
-	const project_dir = path.dirname(find_project_file(uri.fsPath));
-	if (project_dir === null) {
-		return;
-	}
-
-	let relative_path = path.normalize(path.relative(project_dir, uri.fsPath));
-	relative_path = relative_path.split(path.sep).join(path.posix.sep);
-	relative_path = "res://" + relative_path;
+	const relative_path = await convert_uri_to_resource_path(uri);
 
 	vscode.env.clipboard.writeText(relative_path);
 }

--- a/src/providers/document_link.ts
+++ b/src/providers/document_link.ts
@@ -40,7 +40,7 @@ export class GDDocumentLinkProvider implements DocumentLinkProvider {
 				const uri = Uri.from({
 					scheme: "file",
 					path: path,
-					fragment: `${scene.externalResources[id].line},0`,
+					fragment: `${scene.externalResources.get(id).line},0`,
 				});
 
 				const r = this.create_range(document, match);
@@ -54,7 +54,7 @@ export class GDDocumentLinkProvider implements DocumentLinkProvider {
 				const uri = Uri.from({
 					scheme: "file",
 					path: path,
-					fragment: `${scene.subResources[id].line},0`,
+					fragment: `${scene.subResources.get(id).line},0`,
 				});
 
 				const r = this.create_range(document, match);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -49,8 +49,8 @@ export class GDHoverProvider implements HoverProvider {
 			if (word.startsWith("ExtResource")) {
 				const match = word.match(wordPattern);
 				const id = match[1];
-				const resource = scene.externalResources[id];
-				const definition = scene.externalResources[id].body;
+				const resource = scene.externalResources.get(id);
+				const definition = resource.body;
 				const links = await this.get_links(definition);
 
 				const contents = new MarkdownString();
@@ -77,7 +77,7 @@ export class GDHoverProvider implements HoverProvider {
 				const match = word.match(wordPattern);
 				const id = match[1];
 
-				let definition = scene.subResources[id].body;
+				let definition = scene.subResources.get(id).body;
 				// don't display contents of giant arrays
 				definition = definition?.replace(/Array\([0-9,\.\- ]*\)/, "Array(...)");
 

--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -126,7 +126,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 		for (const match of text.matchAll(/ExtResource\(\s?"?(\w+)\s?"?\)/g)) {
 			const id = match[1];
 			const end = document.positionAt(match.index + match[0].length);
-			const resource = scene.externalResources[id];
+			const resource = scene.externalResources.get(id);
 
 			const label = `${resource.type}: "${resource.path}"`;
 
@@ -138,7 +138,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 		for (const match of text.matchAll(/SubResource\(\s?"?(\w+)\s?"?\)/g)) {
 			const id = match[1];
 			const end = document.positionAt(match.index + match[0].length);
-			const resource = scene.subResources[id];
+			const resource = scene.subResources.get(id);
 
 			const label = `${resource.type}`;
 

--- a/src/scene_tools/parser.ts
+++ b/src/scene_tools/parser.ts
@@ -1,6 +1,6 @@
+import * as fs from "node:fs";
+import { basename, extname } from "node:path";
 import { TextDocument, Uri } from "vscode";
-import { basename, extname } from "path";
-import * as fs from "fs";
 import { SceneNode, Scene } from "./types";
 import { createLogger } from "../utils";
 
@@ -46,7 +46,7 @@ export class SceneParser {
 			const uid = line.match(/uid="([\w:/]+)"/)?.[1];
 			const id = line.match(/ id="?([\w]+)"?/)?.[1];
 
-			scene.externalResources[id] = {
+			scene.externalResources.set(id, {
 				body: line,
 				path: path,
 				type: type,
@@ -54,7 +54,7 @@ export class SceneParser {
 				id: id,
 				index: match.index,
 				line: document.lineAt(document.positionAt(match.index)).lineNumber + 1,
-			};
+			});
 		}
 
 		let lastResource = null;
@@ -76,7 +76,7 @@ export class SceneParser {
 				lastResource.body = text.slice(lastResource.index, match.index).trimEnd();
 			}
 
-			scene.subResources[id] = resource;
+			scene.subResources.set(id, resource);
 			lastResource = resource;
 		}
 
@@ -134,9 +134,10 @@ export class SceneParser {
 			scene.nodes.set(_path, node);
 
 			if (instance) {
-				if (instance in scene.externalResources) {
-					node.tooltip = scene.externalResources[instance].path;
-					node.resourcePath = scene.externalResources[instance].path;
+				const res = scene.externalResources.get(instance);
+				if (res) {
+					node.tooltip = res.path;
+					node.resourcePath = res.path;
 					if ([".tscn"].includes(extname(node.resourcePath))) {
 						node.contextValue += "openable";
 					}

--- a/src/scene_tools/preview.ts
+++ b/src/scene_tools/preview.ts
@@ -75,9 +75,11 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 		);
 		const result: string | undefined = this.context.workspaceState.get("godotTools.scenePreview.lockedScene");
 		if (result) {
-			set_context("scenePreview.locked", true);
-			this.scenePreviewLocked = true;
-			this.currentScene = result;
+			if (fs.existsSync(result)) {
+				set_context("scenePreview.locked", true);
+				this.scenePreviewLocked = true;
+				this.currentScene = result;
+			}
 		}
 
 		this.refresh();
@@ -153,6 +155,10 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 	}
 
 	public async refresh() {
+		if (!fs.existsSync(this.currentScene)) {
+			return;
+		}
+
 		const document = await vscode.workspace.openTextDocument(this.currentScene);
 		this.scene = this.parser.parse_scene(document);
 

--- a/src/scene_tools/preview.ts
+++ b/src/scene_tools/preview.ts
@@ -89,7 +89,9 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 		token: vscode.CancellationToken,
 	): void | Thenable<void> {
 		data.set("godot/scene", new vscode.DataTransferItem(this.currentScene));
-		data.set("godot/path", new vscode.DataTransferItem(source[0].relativePath));
+		data.set("godot/node", new vscode.DataTransferItem(source[0]));
+		data.set("godot/path", new vscode.DataTransferItem(source[0].path));
+		data.set("godot/relativePath", new vscode.DataTransferItem(source[0].relativePath));
 		data.set("godot/class", new vscode.DataTransferItem(source[0].className));
 		data.set("godot/unique", new vscode.DataTransferItem(source[0].unique));
 		data.set("godot/label", new vscode.DataTransferItem(source[0].label));
@@ -192,7 +194,7 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 	}
 
 	private async open_script(item: SceneNode) {
-		const path = this.scene.externalResources[item.scriptId].path;
+		const path = this.scene.externalResources.get(item.scriptId).path;
 
 		const uri = await convert_resource_path_to_uri(path);
 		if (uri) {
@@ -211,7 +213,7 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 		if (this.currentScene) {
 			const root = this.scene.root;
 			if (root?.hasScript) {
-				const path = this.scene.externalResources[root.scriptId].path;
+				const path = this.scene.externalResources.get(root.scriptId).path;
 				const uri = await convert_resource_path_to_uri(path);
 				if (uri) {
 					vscode.window.showTextDocument(uri, { preview: true });

--- a/src/scene_tools/preview.ts
+++ b/src/scene_tools/preview.ts
@@ -61,7 +61,7 @@ export class ScenePreviewProvider implements TreeDataProvider<SceneNode>, TreeDr
 			register_command("scenePreview.openScene", this.open_scene.bind(this)),
 			register_command("scenePreview.openScript", this.open_script.bind(this)),
 			register_command("scenePreview.openCurrentScene", this.open_current_scene.bind(this)),
-			register_command("scenePreview.openCurrentScript", this.open_main_script.bind(this)),
+			register_command("scenePreview.openMainScript", this.open_main_script.bind(this)),
 			register_command("scenePreview.goToDefinition", this.go_to_definition.bind(this)),
 			register_command("scenePreview.openDocumentation", this.open_documentation.bind(this)),
 			register_command("scenePreview.refresh", this.refresh.bind(this)),

--- a/src/scene_tools/types.ts
+++ b/src/scene_tools/types.ts
@@ -53,7 +53,7 @@ export class SceneNode extends TreeItem {
 				this.scriptId = line.match(/script = ExtResource\(\s*"?([\w]+)"?\s*\)/)[1];
 				this.contextValue += "hasScript";
 			}
-			if (line != "") {
+			if (line !== "") {
 				newLines.push(line);
 			}
 		}
@@ -79,7 +79,7 @@ export class Scene {
 	public title: string;
 	public mtime: number;
 	public root: SceneNode | undefined;
-	public externalResources: {[key: string]: GDResource} = {};
-	public subResources: {[key: string]: GDResource} = {};
+	public externalResources: Map<string, GDResource> = new Map();
+	public subResources: Map<string, GDResource> = new Map();
 	public nodes: Map<string, SceneNode> = new Map();
 }

--- a/src/utils/godot_utils.ts
+++ b/src/utils/godot_utils.ts
@@ -116,6 +116,17 @@ export async function convert_resource_path_to_uri(resPath: string): Promise<vsc
 	return vscode.Uri.joinPath(vscode.Uri.file(dir), resPath.substring("res://".length));
 }
 
+export async function convert_uri_to_resource_path(uri: vscode.Uri): Promise<string | null> {
+	const project_dir = path.dirname(find_project_file(uri.fsPath));
+	if (project_dir === null) {
+		return;
+	}
+
+	let relative_path = path.normalize(path.relative(project_dir, uri.fsPath));
+	relative_path = relative_path.split(path.sep).join(path.posix.sep);
+	return `res://${relative_path}`;
+}
+
 export type VERIFY_STATUS = "SUCCESS" | "WRONG_VERSION" | "INVALID_EXE";
 export type VERIFY_RESULT = {
 	status: VERIFY_STATUS;


### PR DESCRIPTION
Improves Scene Preview locking by saving the path of the locked scene to workspace storage.

Also implements relative path modification when dragging from the Scene Preview into a script. This resolves #640

Base case, the target script is attached to the scene root:

![Code_SzF5tfCsvI](https://github.com/user-attachments/assets/f8ecd488-bfd9-4f9f-8d63-4779f4eae0f2)

New case, the target script is attached to some other node in the scene:

![Code_fmzGDnCz5r](https://github.com/user-attachments/assets/fad8117f-c265-43bc-97bf-15c37d9d2ad5)

![Code_CEm5lvvOcv](https://github.com/user-attachments/assets/4ffd7194-658d-4f92-979f-256e2227d84f)
