### PR TITLE
Change debug_current_file error message

### DIFF
--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -165,8 +165,8 @@ export class GodotDebugger implements DebugAdapterDescriptorFactory, DebugConfig
 		if (path.endsWith(".gd")) {
 			const scenePath = path.replace(".gd", ".tscn");
 			if (!fs.existsSync(scenePath)) {
-				log.warn(`Can't find associated scene for '${path}', aborting debug`);
-				window.showWarningMessage(`Can't find associated scene file for '${path}'`);
+				log.warn(`Can't find associated scene for '${path}', aborting debug, script and scene file have to share the same name`);
+				window.showWarningMessage(`Can't find associated scene file for '${path}', script and scene file have to share the same name`);
 				return;
 			}
 			path = scenePath;

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -165,8 +165,9 @@ export class GodotDebugger implements DebugAdapterDescriptorFactory, DebugConfig
 		if (path.endsWith(".gd")) {
 			const scenePath = path.replace(".gd", ".tscn");
 			if (!fs.existsSync(scenePath)) {
-				log.warn(`Can't find associated scene for '${path}', aborting debug, script and scene file have to share the same name`);
-				window.showWarningMessage(`Can't find associated scene file for '${path}', script and scene file have to share the same name`);
+				const message = `Can't launch debug session: no associated scene for '${path}'. (Script and scene file must have the same name.)`;
+				log.warn(message);
+				window.showWarningMessage(message);
 				return;
 			}
 			path = scenePath;


### PR DESCRIPTION
Currently, the error message in debug_current_file doesn't tell the user that the scene file and script file must share the same name. This fixes that.