### PR TITLE
update textmate grammar

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -61,6 +61,9 @@
 				{ "include": "#operators" },
 				{ "include": "#lambda_declaration" },
 				{ "include": "#class_declaration" },
+				{
+					"include": "#variable_declaration_name"
+				},
 				{ "include": "#variable_declaration" },
 				{ "include": "#signal_declaration_bare" },
 				{ "include": "#signal_declaration" },
@@ -332,6 +335,15 @@
 				{ "include": "#keywords" }
 			]
 		},
+		"variable_declaration_name": {
+			"name": "meta.variable.declaration.name.gdscript",
+			"match": "(?<=\\b(var|const)\\s+)([A-Za-z_]\\w*)(?!\\s*:=)|(?<=\\s*:=\\s*)([A-Za-z_]\\w*)",
+			"patterns": [
+				{
+					"include": "#any_variable"
+				}
+			]
+		},
 		"getter_setter_godot4": {
 			"patterns": [
 				{
@@ -444,7 +456,7 @@
 			]
 		},
 		"annotations": {
-			"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|static_unload)\\b",
+			"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_tool_button|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|static_unload)\\b",
 			"captures": {
 				"1": { "name": "entity.name.function.decorator.gdscript" },
 				"2": { "name": "entity.name.function.decorator.gdscript" }
@@ -688,3 +700,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
**1. Added export_tool_button Annotation Support**

I added the export_tool_button keyword to the annotation term match list in the grammar file. That way the syntax highlighter properly recognizes and styles this annotation in VScode.

```json
"annotations": {
	"match": "(@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_tool_button|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|static_unload)\\b",
	"captures": {
		"1": { "name": "entity.name.function.decorator.gdscript" },
		"2": { "name": "entity.name.function.decorator.gdscript" }
	}
},
```
---
**2. Added Variable Declaration Name Grammar Support**

I implemented grammar support for variable field name declarations with this pattern:
Also wanted to add grammar support for variable field name declarations like this:
```json
"variable_declaration_name": {
	"name": "meta.variable.declaration.name.gdscript",
	"match": "(?<=\\b(var|const)\\s+)([A-Za-z_]\\w*)(?!\\s*:=)|(?<=\\s*:=\\s*)([A-Za-z_]\\w*)",
	"patterns": [
		{
			"include": "#any_variable"
		}
	]
},
```
The regex pattern captures variable names in two contexts:

1. ```(?<=\\b(var|const)\\s+)([A-Za-z_]\\w*)(?!\\s*:=)``` This looks for words after the var or const keywords but not followed by := (for standard declarations)
2. ```(?<=\\s*:=\\s*)([A-Za-z_]\\w*)``` After the := operator (for inferred type declarations)