### PR TITLE
Update GDScript $ node reference tokenization

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -402,7 +402,7 @@
 			"name": "string.quoted.gdscript meta.literal.nodepath.gdscript constant.character.escape.gdscript",
 			"begin": "(?:(\\$|%)|(&|\\^|@))(\"|')",
 			"beginCaptures": {
-				"1": { "name": "keyword.control.flow.gdscript" },
+				"1": { "name": "constant.character.escape.gdscript" },
 				"2": { "name": "variable.other.enummember.gdscript" }
 			},
 			"end": "(\\3)",
@@ -417,7 +417,7 @@
 			"name": "meta.literal.nodepath.bare.gdscript",
 			"match": "(?<!/\\s*)(\\$\\s*|%|\\$%\\s*)(/\\s*)?([a-zA-Z_]\\w*)\\b(?!\\s*/)",
 			"captures": {
-				"1": { "name": "keyword.control.flow.gdscript" },
+				"1": { "name": "constant.character.escape.gdscript" },
 				"2": { "name": "constant.character.escape.gdscript" },
 				"3": { "name": "constant.character.escape.gdscript" },
 				"4": { "name": "constant.character.escape.gdscript" }
@@ -427,7 +427,7 @@
 			"name": "meta.literal.nodepath.bare.gdscript",
 			"begin": "(\\$\\s*|%|\\$%\\s*)(/\\s*)?([a-zA-Z_]\\w*)",
 			"beginCaptures": {
-				"1": { "name": "keyword.control.flow.gdscript" },
+				"1": { "name": "constant.character.escape.gdscript" },
 				"2": { "name": "constant.character.escape.gdscript" },
 				"3": { "name": "constant.character.escape.gdscript" }
 			},


### PR DESCRIPTION
**Issue**
In the current TextMate grammar for GDScript, the $ symbol used for node references (e.g., $Label) is incorrectly tokenized as keyword.control.flow.gdscript. This causes the symbol to be highlighted with the same color as flow control keywords like if and while, which is semantically incorrect.

**Changes**
This PR changes the tokenization of the $ node reference symbol from keyword.control.flow.gdscript to constant.character.escape.gdscript in all three relevant patterns:
- builtin_get_node_shorthand_quoted
- builtin_get_node_shorthand_bare
- builtin_get_node_shorthand_bare_multi

**Benefits**

- More semantically accurate token classification
- Better visual distinction between flow control keywords and node references
- Consistent highlighting for node path references in GDScript
- Improves readability for developers using the VSCode extension

**Testing**
I've verified these changes with multiple color themes to ensure the highlighting is now consistent and appropriate for this language feature.