### PR TITLE
Fix extension soft lock when inspecting Dictionary variables with Variant key types

### DIFF
--- a/src/debugger/godot4/variables/variant_decoder.ts
+++ b/src/debugger/godot4/variables/variant_decoder.ts
@@ -210,6 +210,9 @@ export class VariantDecoder {
 
 	private decode_ContainerTypeFlag(model: BufferModel, type: GDScriptTypes, bitOffset: number) {
 		const shiftedType = (type >> bitOffset) & 0b11;
+		if (shiftedType === ContainerTypeFlags.NONE) {
+			return 0;
+		}
 		if (shiftedType === ContainerTypeFlags.BUILTIN) {
 			return this.decode_UInt32(model);
 		} else {

--- a/src/debugger/godot4/variables/variants.ts
+++ b/src/debugger/godot4/variables/variants.ts
@@ -58,6 +58,7 @@ export const ENCODE_FLAG_TYPED_ARRAY_MASK = 0b11 << 16;
 export const ENCODE_FLAG_TYPED_DICT_MASK = 0b1111 << 16;
 
 export enum ContainerTypeFlags {
+	NONE = 0,
 	BUILTIN = 1,
 	CLASS_NAME = 2,
 	SCRIPT = 3,


### PR DESCRIPTION
Hello,

In some cases the extension would soft lock making it impossible to inspect variables. The symptoms are very similar to #699, except this time the problem is caused by typed dictionaries that have `Variant` as a value type.

To reproduce try setting a breakpoint in the script below and inspecting contents of `my_dict`.
The issue replicates on Godot 4.4 (and possibly newer versions) on both Windows and MacOs.
```
extends Node

func _ready() -> void:
    var my_dict: Dictionary[int, Variant] = {5: "abc", 31: "Vector3(5, 6, 7)", 63: "xyzW"}
    print("")
```

The solution is to container check type flags and then decode type info only if flag is nonzero. If flag === 0 then there will be no type information included in the buffer.