### PR TITLE
Teach formatter to optionally add two spaces before end-of-line comments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,19 @@
 					"default": false,
 					"description": "Whether extra space should be removed from function parameter lists"
 				},
+				"godotTools.formatter.spacesBeforeEndOfLineComment": {
+					"type": "string",
+					"enum": [
+						"1",
+						"2"
+					],
+					"enumDescriptions": [
+						"1 space before EOL comments # Like this.",
+						"2 spaces before EOL comments  # Like this."
+					],
+					"default": "1",
+					"description": "Number of spaces before an end-of-line comment"
+				},
 				"godotTools.lsp.serverHost": {
 					"type": "string",
 					"default": "127.0.0.1",

--- a/src/formatter/formatter.test.ts
+++ b/src/formatter/formatter.test.ts
@@ -17,6 +17,7 @@ function normalizeLineEndings(str: string) {
 const defaultOptions: FormatterOptions = {
 	maxEmptyLines: 2,
 	denseFunctionParameters: false,
+        spacesBeforeEndOfLineComment: 1
 };
 
 function get_options(folder: fs.Dirent) {

--- a/src/formatter/snapshots/spaces_before_eol_comment.gd
+++ b/src/formatter/snapshots/spaces_before_eol_comment.gd
@@ -1,0 +1,47 @@
+# --- IN ---
+pass # Comment 1.
+pass ## Comment 2.
+
+# --- IN ---
+pass    # Comment 3.
+pass    ## Comment 4.
+# --- OUT ---
+pass # Comment 3.
+pass ## Comment 4.
+
+
+# --- CONFIG ALL ---
+{"spacesBeforeEndOfLineComment": 1}
+
+# --- IN ---
+pass # Comment 5.
+pass ## Comment 6.
+
+# --- IN ---
+pass    # Comment 7.
+pass    ## Comment 8.
+# --- OUT ---
+pass # Comment 7.
+pass ## Comment 8.
+
+
+# --- CONFIG ALL ---
+{"spacesBeforeEndOfLineComment": 2}
+
+# --- IN ---
+pass # Comment 9.
+pass ## Comment A.
+# --- OUT ---
+pass  # Comment 9.
+pass  ## Comment A.
+
+# --- IN ---
+pass  # Comment B.
+pass  ## Comment C.
+
+# --- IN ---
+pass    # Comment D.
+pass    ## Comment E.
+# --- OUT ---
+pass  # Comment D.
+pass  ## Comment E.

--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -56,12 +56,14 @@ interface Token {
 export interface FormatterOptions {
 	maxEmptyLines: 0 | 1 | 2;
 	denseFunctionParameters: boolean;
+        spacesBeforeEndOfLineComment: 1 | 2;
 }
 
 function get_formatter_options() {
 	const options: FormatterOptions = {
 		maxEmptyLines: get_configuration("formatter.maxEmptyLines") === "1" ? 1 : 2,
 		denseFunctionParameters: get_configuration("formatter.denseFunctionParameters"),
+		spacesBeforeEndOfLineComment: get_configuration("formatter.spacesBeforeEndOfLineComment") === "1" ? 1 : 2,
 	};
 
 	return options;
@@ -135,8 +137,8 @@ function between(tokens: Token[], current: number, options: FormatterOptions) {
 
 	if (!prev) return "";
 
-	if (next === "##") return " ";
-	if (next === "#") return " ";
+	if (next === "##") return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
+	if (next === "#") return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
 	if (prevToken.skip && nextToken.skip) return "";
 
 	if (prev === "(") return "";


### PR DESCRIPTION
This change adds a new formatter option for the number of spaces before an end-of-line comment.

Now you can choose 1 space (the current default) or 2 spaces.

Rationale: Some teams have local style guides that require more than one space to introduce EOL comments. Teams having a Python background, for example, are [accustomed to this style](https://peps.python.org/pep-0008/#inline-comments).