### PR TITLE
Added ability to specify editorPath using environment variable (#807)

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,12 +272,12 @@
 				"godotTools.editorPath.godot3": {
 					"type": "string",
 					"default": "godot3",
-					"description": "Path to the Godot 3 editor executable"
+					"description": "Path to the Godot 3 editor executable. Supports environment variables using '${env:VAR_NAME}'."
 				},
 				"godotTools.editorPath.godot4": {
 					"type": "string",
 					"default": "godot",
-					"description": "Path to the Godot 4 editor executable"
+					"description": "Path to the Godot 4 editor executable. Supports environment variables using '${env:VAR_NAME}'."
 				},
 				"godotTools.editor.verbose": {
 					"type": "boolean",

--- a/src/debugger/godot4/variables/debugger_variables.test.ts
+++ b/src/debugger/godot4/variables/debugger_variables.test.ts
@@ -13,6 +13,7 @@ chaiAsPromised.then((module) => {
 
 import { promisify } from "util";
 import { execFile } from "child_process";
+import { clean_godot_path } from "../../../utils";
 const execFileAsync = promisify(execFile);
 
 chai.use(chaiSubset);

--- a/src/debugger/godot4/variables/debugger_variables.test.ts
+++ b/src/debugger/godot4/variables/debugger_variables.test.ts
@@ -225,7 +225,7 @@ suite("DAP Integration Tests - Variable Scopes", () => {
 		// init the godot project by importing it in godot engine:
 		const config = vscode.workspace.getConfiguration("godotTools");
 		// config.update("editorPath.godot4", "godot4", vscode.ConfigurationTarget.Workspace);
-		var godot4_path = config.get<string>("editorPath.godot4");
+		var godot4_path = clean_godot_path(config.get<string>("editorPath.godot4"));
 		// get the path for currently opened project in vscode test instance:
 		console.log("Executing", [godot4_path, "--headless", "--import", workspaceFolder]);
 		const exec_res = await execFileAsync(godot4_path, ["--headless", "--import", workspaceFolder], {

--- a/src/utils/godot_utils.ts
+++ b/src/utils/godot_utils.ts
@@ -228,22 +228,22 @@ export function verify_godot_version(godotPath: string, expectedVersion: "3" | "
 }
 
 export function clean_godot_path(godotPath: string): string {
-	let pathToClean: string = godotPath;
+	let pathToClean = godotPath;
 
-	// Environment variable check 
-	// Regular expression for variable value (between the variable suffix and the next ending curly bracket):
-	// .+? matches any character (except line terminators) between one and unlimited times,
-	// as few times as possible, expanding as needed (lazy)
-	const varValueRegexp: string = ".+?";
-	const pattern = `\\$\\{env:(${varValueRegexp})\\}`;
+	// check for environment variable syntax
+	// looking for: ${env:FOOBAR}
+	// extracts "FOOBAR"
+	const pattern = /\$\{env:(.+?)\}/;
 	const match = godotPath.match(pattern);
 
 	if (match && match.length >= 2)	{
 		pathToClean = process.env[match[1]];
 	}
 
+	// strip leading and trailing quotes
 	let target = pathToClean.replace(/^"/, "").replace(/"$/, "");
 
+	// try to fix macos paths
 	if (os.platform() === "darwin" && target.endsWith(".app")) {
 		target = path.join(target, "Contents", "MacOS", "Godot");
 	}

--- a/src/utils/godot_utils.ts
+++ b/src/utils/godot_utils.ts
@@ -228,7 +228,22 @@ export function verify_godot_version(godotPath: string, expectedVersion: "3" | "
 }
 
 export function clean_godot_path(godotPath: string): string {
-	let target = godotPath.replace(/^"/, "").replace(/"$/, "");
+	let pathToClean: string = godotPath;
+
+	// Environment variable check 
+	// Regular expression for variable value (between the variable suffix and the next ending curly bracket):
+    // .+? matches any character (except line terminators) between one and unlimited times,
+    // as few times as possible, expanding as needed (lazy)
+    const varValueRegexp: string = ".+?";
+	const pattern = `\\$\\{env:(${varValueRegexp})\\}`;
+	const match = godotPath.match(pattern);
+
+	if (match && match.length >= 2)
+	{
+		pathToClean = process.env[match[1]];
+	}
+
+	let target = pathToClean.replace(/^"/, "").replace(/"$/, "");
 
 	if (os.platform() === "darwin" && target.endsWith(".app")) {
 		target = path.join(target, "Contents", "MacOS", "Godot");

--- a/src/utils/godot_utils.ts
+++ b/src/utils/godot_utils.ts
@@ -232,14 +232,13 @@ export function clean_godot_path(godotPath: string): string {
 
 	// Environment variable check 
 	// Regular expression for variable value (between the variable suffix and the next ending curly bracket):
-    // .+? matches any character (except line terminators) between one and unlimited times,
-    // as few times as possible, expanding as needed (lazy)
-    const varValueRegexp: string = ".+?";
+	// .+? matches any character (except line terminators) between one and unlimited times,
+	// as few times as possible, expanding as needed (lazy)
+	const varValueRegexp: string = ".+?";
 	const pattern = `\\$\\{env:(${varValueRegexp})\\}`;
 	const match = godotPath.match(pattern);
 
-	if (match && match.length >= 2)
-	{
+	if (match && match.length >= 2)	{
 		pathToClean = process.env[match[1]];
 	}
 


### PR DESCRIPTION
This is my first attempt at any extension coding, so feel free to give me tips if anything seems off. 
But I noticed that someone had already reported this issue that I also wanted fixed, so it seemed like a good reason to dip my toes in.

Regex section is based on the setup in [vscode-cpptools](https://github.com/microsoft/vscode-cpptools/blob/7e013ab0da5455f6f3734fe7b5a5d2bd4a5a3595/Extension/src/expand.ts#L91) and seems to do the trick. 

Only part I'm unsure about is the section in `debugger_variables.test.ts`. Was there a reason for it not calling `clean_godot_path` previously?