### PR TITLE
Make sure last LSP client is disconnected before creating a new one. 

### DIFF
--- a/src/lsp/ClientConnectionManager.ts
+++ b/src/lsp/ClientConnectionManager.ts
@@ -75,6 +75,8 @@ export class ClientConnectionManager {
 
 	private create_new_client() {
 		const port = this.client?.port ?? -1;
+		this.client?.io?.removeAllListeners();
+		this.client?.stop();
 		this.client?.events?.removeAllListeners();
 		this.client = new GDScriptLanguageClient();
 		this.client.port = port;


### PR DESCRIPTION
The LSP client seems to have left over resources when restarting godot. 
This causes CTRL-hover to fail after restarting godot because multiple `textDocument/definition` requests are sent.

Steps to reproduce issue:
1. Open vscode extension.
1. Open godot project.
1. Within the vscode window CTRL-Click any object.
1. Close + reopen godot.
1. Within the vscode window CTRL-Click any object.

If you have a debuging window open you should see `rx`/`tx` similar to this:
```
[lsp.io] tx: {jsonrpc: '2.0', id: 4, method: 'textDocument/hover', params: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', id: 22, method: 'textDocument/hover', params: {…}}
logger.ts:70
[lsp.io] rx: {id: 4, jsonrpc: '2.0', result: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', method: '$/cancelRequest', params: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', id: 5, method: 'textDocument/definition', params: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', id: 23, method: 'textDocument/definition', params: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', id: 6, method: 'textDocument/hover', params: {…}}
logger.ts:70
[lsp.io] tx: {jsonrpc: '2.0', method: '$/cancelRequest', params: {…}}
logger.ts:70
```

This change disconnects io functions, and stops the last valid LSP client before making a new client.

(I did test this on godot > 4.5 but I have made some local changes so there is a chance that it is not required under the current stable godot version.)