### PR TITLE
Fix VSCode window focus issue in Godot 4 debugger(#692)

### DIFF
--- a/src/debugger/godot4/server_controller.ts
+++ b/src/debugger/godot4/server_controller.ts
@@ -278,7 +278,7 @@ export class ServerController {
 		}
 
 		log.info(`Launching game process using command: '${command}'`);
-		const debugProcess = subProcess("debug", command, { shell: true, detached: true });
+		const debugProcess = subProcess("debug", command, { shell: true});
 
 		debugProcess.stdout.on("data", (data) => {});
 		debugProcess.stderr.on("data", (data) => {});


### PR DESCRIPTION
This commit resolves an issue where VSCode fails to focus the window under specific conditions when debugging Godot 4 projects. The fix ensures proper window focus behavior during debugging sessions.